### PR TITLE
Add pip to dependencies in environment.yaml

### DIFF
--- a/scripts/environment.yaml
+++ b/scripts/environment.yaml
@@ -14,6 +14,7 @@ dependencies:
   - hvplot
   - ipykernel
   - jupyter
+  - pip
   - pyyaml
   - pip:
     - tqdm


### PR DESCRIPTION
Adding pip to dependencies before using it to specify further requirements mutes a warning that otherwise pops up.