### PR TITLE
Add possibility to find meeting point of HALO and Meteor, BCO or CV in a user-defined segment

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -130,7 +130,8 @@ def ec_event(ds, ec_track, ec_remarks=None):
            }
 
 
-def meteor_event(ds, meteor_track, name=None, remarks=None):
+def meteor_event(ds, meteor_track, seg=None, name=None, remarks=None):
+    if seg: ds = ds.sel(time=parse_segment(seg)["slice"])
     dist, meeting_time = get_overpass_track(ds, meteor_track)
     return {"name": name or "METEOR overpass",
             "time": to_dt(meeting_time),
@@ -143,7 +144,7 @@ def meteor_event(ds, meteor_track, name=None, remarks=None):
 
 
 def target_event(ds, target=None, target_lat=None, target_lon=None,
-                 name=None, kinds=None, remarks=None):
+                 seg=None, name=None, kinds=None, remarks=None):
     if target=="BCO":
         from orcestra.flightplan import bco
         target_lat, target_lon = bco.lat, bco.lon
@@ -162,7 +163,8 @@ def target_event(ds, target=None, target_lat=None, target_lon=None,
     else:
         target_name = "target meeting point"
         target_kinds = ["point_overpass"]
-
+    
+    if seg: ds = ds.sel(time=parse_segment(seg)["slice"])
     dist, time = get_overpass_point(ds, target_lat, target_lon)
 
     return {"name": name or target_name,


### PR DESCRIPTION
In some flights there were multiple overpasses of the same reference point (i.e., Meteor, BCO or CVAO). One example is flight HALO-20240903a, which overpassed Meteor twice. However, the functions `meteor_events()` and `target_event()` were designed for only one overpass of a reference point per flight as they determined the closest meeting point of the entire flight. With this PR one can now also pass the flight segment as an argument to those two functions. In case a flight segment is given, the function will now determine the closest meeting point for that segment. If no segment is given, the functions work as before and find the closest meeting point of the whole flight.