### PR TITLE
remove print statements for takeoff and landing

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -266,7 +266,6 @@ def get_takeoff_landing(flight_id, ds):
         airport_takeoff_wgs84 = 90    #Sal
     elif ds.time[0].values >= np.datetime64("2024-09-07T00:00:00"):
         airport_takeoff_wgs84 = 9     #Barbados
-    print(f"Takeoff airport WGS84 altitude: {airport_takeoff_wgs84}m")
     
     # landing airport
     if ds.time[-1].values < np.datetime64("2024-09-05T00:00:00"):
@@ -277,7 +276,6 @@ def get_takeoff_landing(flight_id, ds):
         airport_landing_wgs84 = 9     #Barbados
     elif ds.time[-1].values >= np.datetime64("2024-09-29T00:00:00"):
         airport_landing_wgs84 = 681   #Memmingen
-    print(f"Landing airport WGS84 altitude: {airport_landing_wgs84}m")
     
     takeoff = ds["time"].where(ds.alt > airport_takeoff_wgs84, drop=True)[0].values
     landing = ds["time"].where(ds.alt > airport_landing_wgs84, drop=True)[-1].values


### PR DESCRIPTION
The function to determine takeoff and landing is called in several subfunctions. A print statement within the function seems fine for the debugging, but I'd remove it for general usage.