### PR TITLE
fix, CI: deploy only if build was successful

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -73,7 +73,7 @@ jobs:
             reports
   publish:
     needs: build
-    if: "always() && github.repository_owner == 'orcestra-campaign' && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))"
+    if: "success() && github.repository_owner == 'orcestra-campaign' && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))"
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -73,7 +73,7 @@ jobs:
             reports
   publish:
     needs: build
-    if: "always() && steps.build.outcome == 'success' && github.repository_owner == 'orcestra-campaign' && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))"
+    if: "always() && github.repository_owner == 'orcestra-campaign' && (github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main'))"
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
The PR was broken 😬, it tried to use a feature intended for job steps on a whole job. This change should correct the problem.

* Reverts orcestra-campaign/flight_segmentation#142
* replaces `always()` by `success()`