### PR TITLE
Remove parallel execution of nb in compile.yaml

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -55,7 +55,7 @@ jobs:
           touch ipfs.log  # ensure the file exists such that `tail` doesn't fail.
           ipfs daemon 2>ipfs.log | grep -i -o -m1 'Daemon is ready' & tail -f --pid=$! ipfs.log
       - name: compile segment files
-        run: "make -j"
+        run: "make"
         shell: micromamba-shell {0}
       - name: Archive build artifacts
         if: always()


### PR DESCRIPTION
testing whether removing the async execution of notebooks is still fast enough for our purpose to circumvent the problem of ZMQError stated in issue #144