### PR TITLE
Add PACE

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -7,6 +7,7 @@ __all__ = [
     "get_overpass_track",
     "get_ec_track",
     "ec_event",
+    "pace_event",
     "meteor_event",
     "target_event",
     "to_dt",
@@ -129,6 +130,15 @@ def ec_event(ds, ec_track, ec_remarks=None):
             "kinds": ["ec_underpass"],
             "distance": round(dist), #rounding to full meters
             "remarks": ec_remarks or [],
+           }
+
+def pace_event(ds, pace_track, remarks=None):
+    dist, time = get_overpass_track(ds, pace_track)
+    return {"name": "PACE meeting point",
+            "time": to_dt(time),
+            "kinds": ["pace_underpass"],
+            "distance": round(dist), #rounding to full meters
+            "remarks": remarks or [],
            }
 
 


### PR DESCRIPTION
This PR adds or corrects teh PACE info in two HALO flights that had a collocation in space and time with the PACE satellite. Therefore,
* the `utils.py` received a new function `pace_event`
* HALO-20240916a: PACE info in the notebook is updated and simplified and a test of the YAML output is added
* HALO-20240919a: PACE overpass envent is added and PACE related info updated. I noticed that the segments and events were not consecutive in time and adjusted that in a second commit.