### PR TITLE
add circle direction as kind in all flights

### DIFF
--- a/scripts/segmentation_HALO-20240811a.md
+++ b/scripts/segmentation_HALO-20240811a.md
@@ -158,7 +158,7 @@ ec3 = (
 
 c1 = (
     slice("2024-08-11T14:17:00", "2024-08-11T15:16:17"),
-    ["circle"], "circle_south", [],
+    ["circle", "circle_counterclockwise"], "circle_south", [],
 )
 
 ec4 = (
@@ -170,13 +170,13 @@ ec4 = (
 
 c2 = (
     slice("2024-08-11T16:15:02", "2024-08-11T17:12:53"),
-    ["circle"], "circle_mid",
+    ["circle", "circle_clockwise"], "circle_mid",
     ["uneven sonde spacing: sonde 11 is not evenly spaced between neighbouring sondes in northeastern circle quadrant"],
 )
 
 c3 = (
     slice("2024-08-11T17:22:35", "2024-08-11T18:18:33"),
-    ["circle"], "circle_north",
+    ["circle", "circle_counterclockwise"], "circle_north",
     ["sonde missing: eastern circle quadrant"],
 )
 
@@ -202,7 +202,7 @@ sl3 = (
 
 catr = (
     slice("2024-08-11T19:16:38", "2024-08-11T19:58:01"),
-    ["circle", "atr_coordination"], "ATR_circle", [],
+    ["circle", "atr_coordination", "circle_clockwise"], "ATR_circle", [],
 )
 
 sl4 = (

--- a/scripts/segmentation_HALO-20240813a.md
+++ b/scripts/segmentation_HALO-20240813a.md
@@ -211,7 +211,7 @@ sl_south = (
 
 c1 = (
     slice("2024-08-13 17:21:20", "2024-08-13 18:23:20"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle south",
     ["irregularity: 18:06:02 - 18:12:08 deviation from circle track with roll angle deviations up to +-15 deg due to deep convection"],
 )
@@ -237,7 +237,7 @@ slc1c2c = (
 
 c2 = (
     slice("2024-08-13T19:15:37", "2024-08-13T20:13:48"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle mid",
 )
 
@@ -263,7 +263,7 @@ slc2c3c = (
 
 c3 = (
     slice("2024-08-13T21:09:04", "2024-08-13T22:07:31"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "circle north",
     ["early circle start due to 1st sonde. Roll angle stable after 21:10:04"],
 )
@@ -279,7 +279,7 @@ slc3catr = (
 
 catr = (
     slice("2024-08-13 22:21:00", "2024-08-13 22:59:14"),
-    ["circle", "atr_coordination"],
+    ["circle", "atr_coordination", "circle_counterclockwise"],
     "ATR circle",
 )
 

--- a/scripts/segmentation_HALO-20240816a.md
+++ b/scripts/segmentation_HALO-20240816a.md
@@ -163,7 +163,7 @@ ec5 = (
 
 c1 = (
     slice("2024-08-16T13:56:46", "2024-08-16T14:52:39"),
-    ["circle"], "circle_south",
+    ["circle", "circle_counterclockwise"], "circle_south",
     ["irregularity: turbulences up to plus/minus 4 degree roll angle deviation",
     ],
 )
@@ -175,7 +175,7 @@ ec6 = (
 
 c2 = (
     slice("2024-08-16T15:06:35", "2024-08-16T16:01:44"),
-    ["circle"], "circle_mid", [],
+    ["circle", "circle_clockwise"], "circle_mid", [],
 )
 
 ec61 = (
@@ -198,7 +198,7 @@ ec8 = (
 
 c3 = (
     slice("2024-08-16T16:53:56", "2024-08-16T17:49:40"),
-    ["circle"], "circle_north", [],
+    ["circle", "circle_clockwise"], "circle_north", [],
 )
 
 sl3 = (
@@ -209,7 +209,7 @@ sl3 = (
 
 catr = (
     slice("2024-08-16T19:05:28", "2024-08-16T19:40:18"),
-    ["circle", "atr_coordination"], "ATR_circle", [],
+    ["circle", "atr_coordination", "circle_clockwise"], "ATR_circle", [],
 )
 
 sl4 = (

--- a/scripts/segmentation_HALO-20240818a.md
+++ b/scripts/segmentation_HALO-20240818a.md
@@ -157,7 +157,7 @@ ec1 = (
 
 c1 = (
     slice("2024-08-18T11:24:25", "2024-08-18T12:18:04"),
-    ["circle"], "circle_north", [],
+    ["circle", "circle_counterclockwise"], "circle_north", [],
 )
 
 ec2 = (
@@ -168,7 +168,7 @@ ec2 = (
 
 c2 = (
     slice("2024-08-18T12:53:12", "2024-08-18T13:47:18"),
-    ["circle"], "circle_mid",
+    ["circle", "circle_clockwise"], "circle_mid",
     ["irregularity: turbulence"],
 )
 
@@ -180,7 +180,7 @@ ec3 = (
 
 c3 = (
     slice("2024-08-18T14:28:14", "2024-08-18T15:24:08"),
-    ["circle"], "circle_south", [],
+    ["circle", "circle_clockwise"], "circle_south", [],
 )
 
 ec4 = (
@@ -192,12 +192,12 @@ ec4 = (
 
 c_bm1 = (
     slice("2024-08-18T16:35:28", "2024-08-18T16:57:56"),
-    ["circle", "c_pirouette"], "C_pirouette_small", [],
+    ["circle", "c_pirouette", "circle_clockwise"], "C_pirouette_small", [],
 )
 
 c_bm2 = (
     slice("2024-08-18T17:02:11", "2024-08-18T17:33:23"),
-    ["circle", "c_pirouette"], "C_pirouette_large",
+    ["circle", "c_pirouette", "circle_clockwise"], "C_pirouette_large",
     ["irregularity: minor turbulences 2024-08-18T17:20:00 - 2024-08-18T17:33:23"],
 )
 

--- a/scripts/segmentation_HALO-20240821a.md
+++ b/scripts/segmentation_HALO-20240821a.md
@@ -15,7 +15,7 @@ jupyter:
     name: python3
 ---
 
-# Flight segmentation template
+# Flight segmentation  HALO-20240821a
 
 a template for flight segmentation developers to work your way through the flight track piece by piece and define segments in time. An EC track and circles are exemplarily shown for 2024-08-13. A YAML file containing the segment time slices as well as optionally specified `kinds`, `name`, `irregularities` or `comments` is generated at the end.
 
@@ -172,8 +172,8 @@ seg5 = (
 
 seg6 = (
     slice("2024-08-21T14:09:58", "2024-08-21T15:06:16"),
-    ["circle"],
-    "southern clockwise circle",
+    ["circle", "circle_clockwise"],
+    "southern circle",
     ["irregularity: turbulence up to plus/minues 4 degree roll angle deviation"]
 )
 
@@ -185,8 +185,8 @@ seg7 = (
 
 seg8 = (
     slice("2024-08-21T15:15:38", "2024-08-21T16:12:19"),
-    ["circle"],
-    "middle counterclockwise circle",
+    ["circle", "circle_counterclockwise"],
+    "middle circle",
     ["no sondes dropped due to air traffic", "irregularity: turbulence up to plus/minus 7 degree roll angle deviation"]
 )
 
@@ -198,15 +198,15 @@ seg9 = (
 
 seg10 = (
     slice("2024-08-21T16:54:01", "2024-08-21T17:50:05"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "northern clockwise circle",
     ["slight deviation from circular path between 17:41:12 and 17:45:54 with up to plus/minus 30 degree roll angle deviation"],
 )
 
 seg11 = (
     slice("2024-08-21T17:54:24", "2024-08-21T18:51:27"),
-    ["circle"],
-    "extra northmost counterclockwise circle",
+    ["circle", "circle_counterclockwise"],
+    "extra northmost circle",
 )
 
 seg12 = (

--- a/scripts/segmentation_HALO-20240822a.md
+++ b/scripts/segmentation_HALO-20240822a.md
@@ -156,8 +156,8 @@ seg3 = (
 
 seg4 = (
     slice("2024-08-22T12:50:11", "2024-08-22T13:46:03"),
-    ["circle"],
-    "southern counterclockwise circle",
+    ["circle", "circle_counterclockwise"],
+    "southern circle",
     ["potential Meteor overpass"]
 )
 
@@ -169,8 +169,8 @@ seg5 = (
 
 seg6 = (
     slice("2024-08-22T13:57:24", "2024-08-22T14:54:18"),
-    ["circle"],
-    "middle counterclockwise circle",
+    ["circle", "circle_counterclockwise"],
+    "middle circle",
     ["irregularities: turbulence between 2024-08-22 14:19:07 and 2024-08-22 14:42:09"]
 )
 
@@ -201,15 +201,15 @@ seg10 = (
 
 seg11 = (
     slice("2024-08-22T16:31:26", "2024-08-22T17:01:29"),
-    ["circle"],
-    "counterclockwise ATR circle",
+    ["circle", "circle_counterclockwise"],
+    "ATR circle",
     ["potentially also of kind ATR_coordination (missing flight report)"],
 )
 
 seg12 = (
     slice("2024-08-22T17:08:06", "2024-08-22T18:02:31"),
-    ["circle"],
-    "counterclockwise northern circle",
+    ["circle", "circle_counterclockwise"],
+    "northern circle",
 )
 
 seg13 = (
@@ -244,7 +244,7 @@ seg17 = (
 
 seg19 = (
     slice("2024-08-22T18:49:51", "2024-08-22T19:19:55"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "ATR circle",
     ["irregularity: descent starting at 2024-08-22 19:17:56",
     "potentially also of kind ATR_coordination (missing flight report)"]

--- a/scripts/segmentation_HALO-20240825a.md
+++ b/scripts/segmentation_HALO-20240825a.md
@@ -179,8 +179,8 @@ seg6 = (
 
 seg7 = (
     slice("2024-08-25T11:56:28", "2024-08-25T12:52:34"),
-    ["circle"],
-    "southern counterclockwise circle",
+    ["circle", "circle_counterclockwise"],
+    "southern circle",
     []
 )
 
@@ -193,8 +193,8 @@ seg8 = (
 
 seg9 = (
     slice("2024-08-25T13:18:30", "2024-08-25T14:14:36"),
-    ["circle"],
-    "middle counterclockwise circle",
+    ["circle", "circle_counterclockwise"],
+    "middle circle",
     []
 )
 
@@ -221,8 +221,8 @@ seg12 = (
 
 seg13 = (
     slice("2024-08-25T14:41:41", "2024-08-25T15:36:41"),
-    ["circle"],
-    "northern counterclockwise circle",
+    ["circle", "circle_counterclockwise"],
+    "northern circle",
     []
 )
 
@@ -270,7 +270,7 @@ seg19 = (
 
 seg20 = (
     slice("2024-08-25T17:56:30", "2024-08-25T18:34:32"),
-    ["circle", "atr_coordination"],
+    ["circle", "atr_coordination", "circle_counterclockwise"],
     "ATR circle",
     []
 )

--- a/scripts/segmentation_HALO-20240827a.md
+++ b/scripts/segmentation_HALO-20240827a.md
@@ -12,7 +12,7 @@ jupyter:
     name: python3
 ---
 
-# Flight segmentation for HALO-20240827a
+# Flight segmentation HALO-20240827a
 
 ```python
 import matplotlib
@@ -198,8 +198,8 @@ seg10 = (
 
 seg11 = (
     slice("2024-08-27T11:59:38", "2024-08-27T12:56:05"),
-    ["circle"],
-    "counterclockwise southern circle",
+    ["circle", "circle_counterclockwise"],
+    "southern circle",
 )
 
 seg12 = (
@@ -215,8 +215,8 @@ seg13 = (
 
 seg14 = (
     slice("2024-08-27T13:14:37", "2024-08-27T14:14:09"),
-    ["circle"],
-    "counterclockwise middle circle",
+    ["circle", "circle_counterclockwise"],
+    "middle circle",
     ["irregularity: due to turbulences at 13:36:46-13:38:08 and 14:02:03-14:03:21"]
 )
 
@@ -229,8 +229,8 @@ seg15 = (
 
 seg16 = (
     slice("2024-08-27T14:50:53", "2024-08-27T15:50:27"),
-    ["circle"],
-    "counterclockwise nothern circle",
+    ["circle", "circle_counterclockwise"],
+    "nothern circle",
     ["end of BAHAMAS measurement gap: 14:57:20"]
 )
 
@@ -272,8 +272,8 @@ seg21 = (
 
 seg22 = (
     slice("2024-08-27T17:43:57", "2024-08-27T18:19:07"),
-    ["circle", "ATR_coordination"],
-    "counterclockwise ATR circle",
+    ["circle", "ATR_coordination", "circle_counterclockwise"],
+    "ATR circle",
     ["sonde failures"]
 )
 

--- a/scripts/segmentation_HALO-20240829a.md
+++ b/scripts/segmentation_HALO-20240829a.md
@@ -177,8 +177,8 @@ seg6 = (
 
 seg7 = (
     slice("2024-08-29T14:05:48", "2024-08-29T15:04:22"),
-    ["circle"],
-    "counterclockwise southern circle"
+    ["circle", "circle_counterclockwise"],
+    "southern circle"
 )
 
 seg8 = (
@@ -204,7 +204,7 @@ seg10 = (
 
 seg11 = (
     slice("2024-08-29T16:11:49", "2024-08-29T17:02:01"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "middle circle with turn",
     ["irregularity: circle not completed due to active convection",
      "irregularity: first sonde dropped before entering the circle",
@@ -219,8 +219,8 @@ seg12 = (
 
 seg13 = (
     slice("2024-08-29T17:39:30", "2024-08-29T18:40:31"),
-    ["circle"],
-    "counterclockwise northern circle",
+    ["circle", "circle_counterclockwise"],
+    "northern circle",
 )
 
 seg14 = (
@@ -251,7 +251,7 @@ seg17 = (
 
 seg18 = (
     slice("2024-08-29T19:09:18", "2024-08-29T19:46:09"),
-    ["circle", "ATR_coordination"],
+    ["circle", "ATR_coordination", "circle_clockwise"],
     "ATR circle",
 )
 

--- a/scripts/segmentation_HALO-20240831a.md
+++ b/scripts/segmentation_HALO-20240831a.md
@@ -197,8 +197,8 @@ seg8 = (
 
 seg9 = (
     slice("2024-08-31T11:22:15", "2024-08-31T12:19:36"),
-    ["circle"],
-    "southern counterclockwise circle",
+    ["circle", "circle_counterclockwise"],
+    "southern circle",
     []
 )
 
@@ -225,8 +225,8 @@ seg12 = (
 
 seg13 = (
     slice("2024-08-31T12:52:25", "2024-08-31T13:48:01"),
-    ["circle"],
-    "middle counterclockwise circle",
+    ["circle", "circle_counterclockwise"],
+    "middle circle",
     ["irregularity: turbulence with up to plus/minus 4.5 degree roll angle deviation"]
 )
 
@@ -240,8 +240,8 @@ seg14 = (
 
 seg15 = (
     slice("2024-08-31T14:19:59", "2024-08-31T15:16:01"),
-    ["circle"],
-    "northern counterclockwise circle",
+    ["circle", "circle_counterclockwise"],
+    "northern circle",
     []
 )
 
@@ -268,7 +268,7 @@ seg18 = (
 
 seg19 = (
     slice("2024-08-31T16:27:38", "2024-08-31T17:03:55"),
-    ["circle", "atr_coordination"],
+    ["circle", "atr_coordination", "circle_clockwise"],
     "ATR circle",
     []
 )

--- a/scripts/segmentation_HALO-20240903a.md
+++ b/scripts/segmentation_HALO-20240903a.md
@@ -157,7 +157,7 @@ ec1 = (
 
 c1 = (
     slice("2024-09-03T13:47:43", "2024-09-03 14:42:01"),
-    ["circle"], "circle_south",
+    ["circle", "circle_counterclockwise"], "circle_south",
     ["partly uneven sonde spacing", "turbulence: 2024-09-03T14:03:50 - 2024-09-03T14:05:00",],
 )
 
@@ -181,7 +181,7 @@ ec4 = (
 
 c2 = (
     slice("2024-09-03T15:02:21", "2024-09-03 15:57:08"),
-    ["circle"], "circle_mid",
+    ["circle", "circle_counterclockwise"], "circle_mid",
     ["irregularity: turbulence 2024-09-03T15:17:40 - 2024-09-03T15:29:25",
      "irregularity: turbulence 2024-09-03T15:46:16 - 2024-09-03T15:46:25",],
 )
@@ -194,7 +194,7 @@ ec5 = (
 
 c3 = (
     slice("2024-09-03 16:36:35", "2024-09-03 17:31:22"),
-    ["circle"], "circle_north",
+    ["circle", "circle_counterclockwise"], "circle_north",
     ["ascent: 2024-09-03T16:44:14 - 2024-09-03T16:49:36"],
 )
 
@@ -221,7 +221,7 @@ sl5 = (
 
 catr1 = (
     slice("2024-09-03 19:01:06", "2024-09-03 19:06:37"),
-    ["circle", "atr_coordination"],
+    ["circle", "atr_coordination", "circle_counterclockwise"],
     "quarter_ATR_circle", ["quarter ATR circle: northeastern quadrant"],
 )
 
@@ -233,7 +233,7 @@ sl6 = (
     
 catr2 = (
     slice("2024-09-03 19:24:51", "2024-09-03 19:54:15"),
-    ["circle", "atr_coordination"],
+    ["circle", "atr_coordination", "circle_counterclockwise"],
     "ATR_circle", ["irregularity: deviation from circle 2024-09-03T19:37:56 - 2024-09-03T19:42:08"],
 )
 

--- a/scripts/segmentation_HALO-20240906a.md
+++ b/scripts/segmentation_HALO-20240906a.md
@@ -227,7 +227,7 @@ sl13_2 = (
 
 c1 = (
     slice("2024-09-06T15:23:12", "2024-09-06T16:21:35"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle west",
 )
 # c1_1 = (

--- a/scripts/segmentation_HALO-20240907a.md
+++ b/scripts/segmentation_HALO-20240907a.md
@@ -111,96 +111,15 @@ plt.legend();
 ## Interactive plots
 
 ```python
-import holoviews as hv
-c1 = 'ForestGreen'
-c2 = 'Purple'
-c3 = 'Orange'
-c4 = 'Blue'
-lw = 2
-
-tko = hv.VLine(takeoff).opts(color = c1, line_width = lw)
-ldn = hv.VLine(landing).opts(color = c1, line_width = lw)
-
-# segment boundaries  
-seg1s = hv.VLine(pd.Timestamp("2024-09-07T12:56:12")).opts(color = c2, line_width = lw) # straight_leg ascent
-seg1e = hv.VLine(pd.Timestamp("2024-09-07T13:22:03")).opts(color = c2, line_width = lw)
-
-seg2s = hv.VLine(pd.Timestamp("2024-09-07T13:22:03")).opts(color = c3, line_width = lw) # straight_leg
-seg2e = hv.VLine(pd.Timestamp("2024-09-07T13:53:07")).opts(color = c3, line_width = lw)
-
-seg3s = hv.VLine(pd.Timestamp("2024-09-07T13:53:44")).opts(color = c4, line_width = lw) # straight_leg
-seg3e = hv.VLine(pd.Timestamp("2024-09-07T13:55:33")).opts(color = c4, line_width = lw)
-
-seg4s = hv.VLine(pd.Timestamp("2024-09-07T13:56:21")).opts(color = c1, line_width = lw) # straight_leg
-seg4e = hv.VLine(pd.Timestamp("2024-09-07T14:27:45")).opts(color = c1, line_width = lw)
-
-seg5s = hv.VLine(pd.Timestamp("2024-09-07T14:35:21")).opts(color = c2, line_width = lw) # straight_leg
-seg5e = hv.VLine(pd.Timestamp("2024-09-07T14:38:38")).opts(color = c2, line_width = lw)
-
-seg6s = hv.VLine(pd.Timestamp("2024-09-07T14:43:35")).opts(color = c3, line_width = lw) # straight_leg
-seg6e = hv.VLine(pd.Timestamp("2024-09-07T14:51:22")).opts(color = c3, line_width = lw)
-
-seg7s = hv.VLine(pd.Timestamp("2024-09-07T14:54:12")).opts(color = c4, line_width = lw) # counterclockwise circle
-seg7e = hv.VLine(pd.Timestamp("2024-09-07T15:49:25")).opts(color = c4, line_width = lw)
-
-seg8s = hv.VLine(pd.Timestamp("2024-09-07T15:53:28")).opts(color = c1, line_width = lw) # straight_leg
-seg8e = hv.VLine(pd.Timestamp("2024-09-07T15:55:18")).opts(color = c1, line_width = lw)
-
-seg9s = hv.VLine(pd.Timestamp("2024-09-07T15:59:33")).opts(color = c2, line_width = lw) # counterclockwise circle
-seg9e = hv.VLine(pd.Timestamp("2024-09-07T17:01:03")).opts(color = c2, line_width = lw)
-
-seg10s = hv.VLine(pd.Timestamp("2024-09-07T17:05:28")).opts(color = c3, line_width = lw) # straight_leg ascent
-seg10e = hv.VLine(pd.Timestamp("2024-09-07T17:08:09")).opts(color = c3, line_width = lw)
-
-seg11s = hv.VLine(pd.Timestamp("2024-09-07T17:10:25")).opts(color = c4, line_width = lw) # straight_leg
-seg11e = hv.VLine(pd.Timestamp("2024-09-07T17:36:23")).opts(color = c4, line_width = lw)
-
-# Inbetween these segments there are a couple of seeminly straight legs where the heading is constant but the roll angle is around 1.2 degrees.
-
-seg12s = hv.VLine(pd.Timestamp("2024-09-07T17:51:40")).opts(color = c1, line_width = lw) # clockwise circle
-seg12e = hv.VLine(pd.Timestamp("2024-09-07T18:59:37")).opts(color = c1, line_width = lw)
-
-seg13s = hv.VLine(pd.Timestamp("2024-09-07T19:02:48")).opts(color = c2, line_width = lw) # straight_leg
-seg13e = hv.VLine(pd.Timestamp("2024-09-07T19:31:16")).opts(color = c2, line_width = lw)
-
-seg14s = hv.VLine(pd.Timestamp("2024-09-07T19:32:37")).opts(color = c3, line_width = lw) # straight_leg
-seg14e = hv.VLine(pd.Timestamp("2024-09-07T19:36:31")).opts(color = c3, line_width = lw)
-
-seg15s = hv.VLine(pd.Timestamp("2024-09-07T19:38:24")).opts(color = c4, line_width = lw) # straight_leg
-seg15e = hv.VLine(pd.Timestamp("2024-09-07T19:46:37")).opts(color = c4, line_width = lw)
-
-seg16s = hv.VLine(pd.Timestamp("2024-09-07T19:47:48")).opts(color = c1, line_width = lw) # straight_leg
-seg16e = hv.VLine(pd.Timestamp("2024-09-07T20:14:41")).opts(color = c1, line_width = lw)
-
-seg17s = hv.VLine(pd.Timestamp("2024-09-07T20:16:46")).opts(color = c2, line_width = lw) # straight_leg descent
-seg17e = hv.VLine(pd.Timestamp("2024-09-07T20:22:00")).opts(color = c2, line_width = lw)
-
-seg18s = hv.VLine(pd.Timestamp("2024-09-07T20:22:19")).opts(color = c3, line_width = lw) # straight_leg descent
-seg18e = hv.VLine(pd.Timestamp("2024-09-07T20:35:50")).opts(color = c3, line_width = lw)
-
-seg19s = hv.VLine(pd.Timestamp("2024-09-07T20:36:50")).opts(color = c4, line_width = lw) # straight_leg descent irregularity: turbulences (roll angles beyond plus/minus 1 degree)
-seg19e = hv.VLine(pd.Timestamp("2024-09-07T20:40:31")).opts(color = c4, line_width = lw)
+ds["alt"].hvplot()
 ```
 
 ```python
-alt = ds["alt"].hvplot()
-alt * tko * ldn * \
- seg1s * seg1e * seg2s * seg2e * seg3s * seg3e * seg4s * seg4e * seg5s * seg5e * seg6s * seg6e * seg7s * seg7e * seg8s * seg8e * seg9s * seg9e * \
- seg10s * seg10e * seg11s * seg11e * seg12s * seg12e * seg13s * seg13e * seg14s * seg14e * seg15s * seg15e * seg16s * seg16e * seg17s * seg17e * seg18s * seg18e * seg19s * seg19e 
+ds["heading"].hvplot()
 ```
 
 ```python
-heading = ds["heading"].hvplot()
-heading * tko * ldn * \
- seg1s * seg1e * seg2s * seg2e * seg3s * seg3e * seg4s * seg4e * seg5s * seg5e * seg6s * seg6e * seg7s * seg7e * seg8s * seg8e * seg9s * seg9e * \
- seg10s * seg10e * seg11s * seg11e * seg12s * seg12e * seg13s * seg13e * seg14s * seg14e * seg15s * seg15e * seg16s * seg16e * seg17s * seg17e * seg18s * seg18e * seg19s * seg19e 
-```
-
-```python
-roll = ds["roll"].hvplot()
-roll * tko * ldn * \
- seg1s * seg1e * seg2s * seg2e * seg3s * seg3e * seg4s * seg4e * seg5s * seg5e * seg6s * seg6e * seg7s * seg7e * seg8s * seg8e * seg9s * seg9e * \
- seg10s * seg10e * seg11s * seg11e * seg12s * seg12e * seg13s * seg13e * seg14s * seg14e * seg15s * seg15e * seg16s * seg16e * seg17s * seg17e * seg18s * seg18e * seg19s * seg19e
+ds["roll"].hvplot()
 ```
 
 ## Segments
@@ -258,8 +177,8 @@ seg6 = (
 
 seg7 = (
     slice("2024-09-07T14:54:12", "2024-09-07T15:49:25"),
-    ["circle"],
-    "counterclockwise southern circle",
+    ["circle", "circle_counterclockwise"],
+    "southern circle",
     ["14 sondes, 2 last ones with only 23 sec time difference"]
 )
 
@@ -272,8 +191,8 @@ seg8 = (
 
 seg9 = (
     slice("2024-09-07T15:59:33", "2024-09-07T17:01:03"),
-    ["circle"],
-    "counterclockwise middle circle",
+    ["circle", "circle_counterclockwise"],
+    "middle circle",
     ["irregularities: permission denied for some sondes which were then dropped on straight leg through circle instead"]
 )
 
@@ -293,8 +212,8 @@ seg11 = (
 
 seg12 = (
     slice("2024-09-07T17:51:40", "2024-09-07T18:59:37"),
-    ["circle"],
-    "clockwise northern circle",
+    ["circle", "circle_clockwise"],
+    "northern circle",
     ["more than full circle"]
 )
 

--- a/scripts/segmentation_HALO-20240909a.md
+++ b/scripts/segmentation_HALO-20240909a.md
@@ -150,7 +150,7 @@ sl2 = (
 
 c1 = (
     slice("2024-09-09T13:49:10", "2024-09-09T14:45:24"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle south",
 )
 
@@ -168,7 +168,7 @@ slc1_2 = (
 
 c2 = (
     slice("2024-09-09T15:13:57", "2024-09-09T16:09:04"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle mid",
 )
 
@@ -193,7 +193,7 @@ ec_south = (
 
 c3 = (
     slice("2024-09-09T17:35:00", "2024-09-09T18:30:50"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle north",
     ["irregularity: early start of circle due to dropsondes, constant roll angle after 17:35:19"]
 )

--- a/scripts/segmentation_HALO-20240912a.md
+++ b/scripts/segmentation_HALO-20240912a.md
@@ -15,7 +15,7 @@ jupyter:
     name: python3
 ---
 
-# Flight segmentation template
+# Flight segmentation HALO-20240912a
 
 a template for flight segmentation developers to work your way through the flight track piece by piece and define segments in time. An EC track and circles are exemplarily shown for 2024-08-13. A YAML file containing the segment time slices as well as optionally specified `kinds`, `name`, `irregularities` or `comments` is generated at the end.
 
@@ -121,88 +121,16 @@ plt.legend();
 
 ## Interactive plots
 
-```python jupyter={"source_hidden": true}
-# c1 = 'ForestGreen'
-# c2 = 'Purple'
-# c3 = 'Orange'
-# c4 = 'Blue'
-# lw = 2
-
-# takeoff = hv.VLine(pd.Timestamp("2024-09-12T11:29:50")).opts(color = c1, line_width = lw)
-# landing = hv.VLine(pd.Timestamp("2024-09-12T20:05:05")).opts(color = c1, line_width = lw)
-
-# # segment boundaries  
-# seg1s = hv.VLine(pd.Timestamp("2024-09-12T11:33:02")).opts(color = c2, line_width = lw) #
-# seg1e = hv.VLine(pd.Timestamp("2024-09-12T11:46:57")).opts(color = c2, line_width = lw)
-
-# seg2s = hv.VLine(pd.Timestamp("2024-09-12T11:52:44")).opts(color = c3, line_width = lw) #
-# seg2e = hv.VLine(pd.Timestamp("2024-09-12T12:01:28")).opts(color = c3, line_width = lw)
-
-# seg3s = hv.VLine(pd.Timestamp("2024-09-12T12:01:28")).opts(color = c4, line_width = lw) #
-# seg3e = hv.VLine(pd.Timestamp("2024-09-12T12:35:09")).opts(color = c4, line_width = lw)
-
-# seg4s = hv.VLine(pd.Timestamp("2024--09-12T12:36:26")).opts(color = c1, line_width = lw) #
-# seg4e = hv.VLine(pd.Timestamp("2024-09-12T13:02:59")).opts(color = c1, line_width = lw)
-
-# seg5s = hv.VLine(pd.Timestamp("2024-09-12T13:06:18")).opts(color = c2, line_width = lw) #circle
-# seg5e = hv.VLine(pd.Timestamp("2024-09-12T14:02:18")).opts(color = c2, line_width = lw)
-
-# seg6s = hv.VLine(pd.Timestamp("2024-09-12T14:06:42")).opts(color = c3, line_width = lw)
-# seg6e = hv.VLine(pd.Timestamp("2024-09-12T14:12:06")).opts(color = c3, line_width = lw)
-
-# seg7s = hv.VLine(pd.Timestamp("2024-09-12T14:18:20")).opts(color = c1, line_width = lw) #circle
-# seg7e = hv.VLine(pd.Timestamp("2024-09-12T15:10:37")).opts(color = c1, line_width = lw)
-
-# seg8s = hv.VLine(pd.Timestamp("2024-09-12T15:13:08")).opts(color = c2, line_width = lw) #
-# seg8e = hv.VLine(pd.Timestamp("2024-09-12T15:18:19")).opts(color = c2, line_width = lw)
-
-# seg9s = hv.VLine(pd.Timestamp("2024-09-12T15:22:30")).opts(color = c3, line_width = lw) #
-# seg9e = hv.VLine(pd.Timestamp("2024-09-12T15:45:40")).opts(color = c3, line_width = lw)
-
-# seg10s = hv.VLine(pd.Timestamp("2024-09-12T15:46:03")).opts(color = c2, line_width = lw) #small circle holding pattern
-# seg10e = hv.VLine(pd.Timestamp("2024-09-12T15:51:48")).opts(color = c2, line_width = lw)
-
-# seg11s = hv.VLine(pd.Timestamp("2024-09-12T15:56:35")).opts(color = c4, line_width = lw) #circle
-# seg11e = hv.VLine(pd.Timestamp("2024-09-12T17:03:46")).opts(color = c4, line_width = lw)
-
-# seg12s = hv.VLine(pd.Timestamp("2024-09-12T17:12:26")).opts(color = c1, line_width = lw) #
-# seg12e = hv.VLine(pd.Timestamp("2024-09-12T17:53:12")).opts(color = c1, line_width = lw)
-
-# seg13s = hv.VLine(pd.Timestamp("2024-09-12T17:55:29")).opts(color = c2, line_width = lw) #circle
-# seg13e = hv.VLine(pd.Timestamp("2024-09-12T18:55:02")).opts(color = c2, line_width = lw)
-
-# seg14s = hv.VLine(pd.Timestamp("2024-09-12T18:56:07")).opts(color = c3, line_width = lw) #
-# seg14e = hv.VLine(pd.Timestamp("2024-09-12T19:41:13")).opts(color = c3, line_width = lw)
-
-# seg15s = hv.VLine(pd.Timestamp("2024-09-12T19:41:13")).opts(color = c4, line_width = lw) #
-# seg15e = hv.VLine(pd.Timestamp("2024-09-12T19:45:16")).opts(color = c4, line_width = lw)
-
-# seg16s = hv.VLine(pd.Timestamp("2024-09-12T19:46:30")).opts(color = c1, line_width = lw) #
-# seg16e = hv.VLine(pd.Timestamp("2024-09-12T19:58:55")).opts(color = c1, line_width = lw)
-
-# seg17s = hv.VLine(pd.Timestamp("2024-09-12T20:01:27")).opts(color = c2, line_width = lw) #
-# seg17e = hv.VLine(pd.Timestamp("2024-09-12T20:05:05")).opts(color = c2, line_width = lw)
+```python
+ds["alt"].hvplot()
 ```
 
-```python jupyter={"source_hidden": true}
-# alt = ds["alt"].hvplot()
-# alt * takeoff * landing * \
-#  seg1s * seg1e * seg2s * seg2e * seg3s * seg3e * seg4s * seg4e * seg5s * seg5e * seg6s * seg6e * seg7s * seg7e * seg8s * seg8e * seg9s * seg9e * \
-# seg10s * seg10e * seg11s * seg11e * seg12s * seg12e * seg13s * seg13e * seg14s * seg14e * seg15s * seg15e * seg16s * seg16e * seg17s * seg17e
+```python
+ds["heading"].hvplot()
 ```
 
-```python jupyter={"source_hidden": true}
-# heading = ds["heading"].hvplot()
-# heading * takeoff * landing * \
-#  seg1s * seg1e * seg2s * seg2e * seg3s * seg3e * seg4s * seg4e * seg5s * seg5e * seg6s * seg6e * seg7s * seg7e * seg8s * seg8e * seg9s * seg9e * \
-#  seg10s * seg10e * seg11s * seg11e * seg12s * seg12e * seg13s * seg13e * seg14s * seg14e * seg15s * seg15e * seg16s * seg16e * seg17s * seg17e
-```
-
-```python jupyter={"source_hidden": true}
-# roll = ds["roll"].hvplot()
-# roll * takeoff * landing * \
-#  seg1s * seg1e * seg2s * seg2e * seg3s * seg3e * seg4s * seg4e * seg5s * seg5e * seg6s * seg6e * seg7s * seg7e * seg8s * seg8e * seg9s * seg9e * \
-#  seg10s * seg10e * seg11s * seg11e * seg12s * seg12e * seg13s * seg13e * seg14s * seg14e * seg15s * seg15e * seg16s * seg16e * seg17s * seg17e
+```python
+ds["roll"].hvplot()
 ```
 
 ## Segments
@@ -242,8 +170,8 @@ seg4 = (
 
 seg5 = (
     slice("2024-09-12T13:06:53", "2024-09-12T14:02:18"),
-    ["circle"],
-    "clockwise eastern circle",
+    ["circle", "circle_clockwise"],
+    "eastern circle",
 )
 
 seg6 = (
@@ -255,8 +183,8 @@ seg6 = (
 
 seg7 = (
     slice("2024-09-12T14:18:20", "2024-09-12T15:10:37"),
-    ["circle"],
-    "counterclockwise north-eastern circle",
+    ["circle", "circle_counterclockwise"],
+    "north-eastern circle",
 )
 
 seg8 = (
@@ -280,8 +208,8 @@ seg9 = (
 
 seg11 = (
     slice("2024-09-12T16:03:30", "2024-09-12T17:03:44"),
-    ["circle"],
-    "counterclockwise north-western circle",
+    ["circle", "circle_counterclockwise"],
+    "north-western circle",
 )
 
 seg12 = (
@@ -293,8 +221,8 @@ seg12 = (
 
 seg13 = (
     slice("2024-09-12T17:56:13", "2024-09-12T18:55:00"),
-    ["circle"],
-    "clockwise western circle",
+    ["circle", "circle_clockwise"],
+    "western circle",
 )
 
 seg14 = (

--- a/scripts/segmentation_HALO-20240914a.md
+++ b/scripts/segmentation_HALO-20240914a.md
@@ -162,7 +162,7 @@ sl4 = (
 
 c1a = (
     slice("2024-09-14T12:55:49", "2024-09-14T13:54:25"),#55:35
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle 1a",
     ["heavy problems with dropsonde reck resulted in only three dropsonde profiles"]
 )
@@ -186,13 +186,13 @@ slc1c2 = (
 
 c2 = (
     slice("2024-09-14T14:52:41", "2024-09-14T15:50:44"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "circle 2",
 )
 
 c3 = (
     slice("2024-09-14T15:54:54", "2024-09-14T16:54:20"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "circle 3",
     ["irregularity: roll angle deviations up to 3.4 degree at 16:12:32, 16:17:02, 16:48:04, and 16:50:04"],
 )
@@ -213,7 +213,7 @@ ec2 = (
 )
 c4 = (
     slice("2024-09-14T17:40:41", "2024-09-14T18:36:44"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "circle 4",
 )
 

--- a/scripts/segmentation_HALO-20240916a.md
+++ b/scripts/segmentation_HALO-20240916a.md
@@ -15,7 +15,7 @@ jupyter:
     name: python3
 ---
 
-# Flight segmentation HALO-2024-09-16a
+# Flight segmentation HALO-20240916a
 
 ```python
 import matplotlib
@@ -158,7 +158,7 @@ sl2 = (
 
 c1 = (
     slice("2024-09-16T13:19:35", "2024-09-16T14:19:45"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle_middle",
     ["irregularity: turbulence 2024-09-16T13:19:35 - 2024-09-16T13:28:00 with roll angle deviation up to +-3.2 deg"],
 )
@@ -170,9 +170,9 @@ sl3a = (
 
 c2 = (
     slice("2024-09-16T14:32:45", "2024-09-16T15:46:32"),
-    ["circle"],
+    ["circle", "circle_counterclockwise", "circle_clockwise"],
     "circle_south",
-    ["irregularity: two half circles with straight leg in between"],
+    ["irregularity: two half circles with straight leg in between, first half counterclockwise, second half clockwise"],
 )
 
 sl3b = (
@@ -216,7 +216,7 @@ ec1c = (
 
 c3 = (
     slice("2024-09-16T17:54:25", "2024-09-16T19:10:50"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "circle_north",
     ["quarter circle without sondes followed by full circle"]
 )

--- a/scripts/segmentation_HALO-20240919a.md
+++ b/scripts/segmentation_HALO-20240919a.md
@@ -15,7 +15,7 @@ jupyter:
     name: python3
 ---
 
-# Flight segmentation HALO-2024-09-19a
+# Flight segmentation HALO-20240919a
 
 ```python
 import matplotlib
@@ -154,7 +154,7 @@ sl1 = (
 
 c1 = (
     slice("2024-09-19 12:35:30", "2024-09-19 13:30:35"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle_1",
     ["irregularity: turbulence 12:32:30 - 12:48:00 with up to +-25 deg roll angle deviation"],
 )
@@ -168,13 +168,13 @@ sl2 = (
 
 c2 = (
     slice("2024-09-19 13:58:32", "2024-09-19 14:53:20"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle_2",
 )
 
 catr = (
     slice("2024-09-19 15:03:25", "2024-09-19 15:33:36"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "small circle",
     [],
     ["smaller radius due to time limitations"],
@@ -202,7 +202,7 @@ sl3c= (
 
 c4 = (
     slice("2024-09-19 16:30:13", "2024-09-19 17:25:15"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "circle_4",
 )
 
@@ -221,7 +221,7 @@ cal = (
 
 c5 = (
     slice("2024-09-19 18:04:55", "2024-09-19 19:04:15"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "circle_5",
 )
 

--- a/scripts/segmentation_HALO-20240921a.md
+++ b/scripts/segmentation_HALO-20240921a.md
@@ -15,7 +15,7 @@ jupyter:
     name: python3
 ---
 
-# Flight segmentation HALO-2024-09-21a
+# Flight segmentation HALO-20240921a
 
 ```python
 import matplotlib
@@ -143,7 +143,7 @@ ac1 = (
 
 c1 = (
     slice("2024-09-21 11:50:36", "2024-09-21 12:47:15"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle_1",
     ["irregularity: ascent until 11:54:12"],
 )
@@ -189,14 +189,14 @@ sl2 = (
 
 c2 = (
     slice("2024-09-21 13:55:00", "2024-09-21 14:52:00"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle_2",
     ["irregularity: deviation from circular path 14:12:00 - 14:20:00 with roll angle deviation up tp +-27.8 deg"],
 )
 
 c3 = (
     slice("2024-09-21 14:52:00", "2024-09-21 15:54:00"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle_3",
     ["irregularity: deviation from circular path 15:10:13 - 15:16:05 with roll angle deviation up tp +-19.2 deg"],
 )
@@ -221,7 +221,7 @@ sl4 = (
 
 c4 = (
     slice("2024-09-21 16:19:50", "2024-09-21 17:15:10"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "circle_4",
 )
 
@@ -252,7 +252,7 @@ sl6 = (
 
 c5 = (
     slice("2024-09-21 18:26:16", "2024-09-21 19:24:15"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle_5",
 )
 

--- a/scripts/segmentation_HALO-20240923a.md
+++ b/scripts/segmentation_HALO-20240923a.md
@@ -122,9 +122,7 @@ if foto:
         plt.scatter(da_foto.lon, da_foto.lat, color='C1', marker='o', s = 10, zorder=100)
 ```
 
-<!-- #region jp-MarkdownHeadingCollapsed=true -->
 ## Interactive plots
-<!-- #endregion -->
 
 ```python
 ds["alt"].hvplot()
@@ -153,13 +151,13 @@ seg1 = (slice("2024-09-23T11:17:49", "2024-09-23T11:18:39"),
 
 # climbing circle (with Meteor overpass)
 seg2 = (slice("2024-09-23T11:21:42", "2024-09-23T11:54:32"),
-        ["ascent", "circle"],
+        ["ascent", "circle", "circle_clockwise"],
         "climbing circle",
         ["circle to climb up to FL410", "including 2nd METEOR overpass"],
        )
 # Meteor measurement circle (with Meteor overpass) on FL410
 seg3 = (slice("2024-09-23T11:54:32", "2024-09-23T12:26:35"),
-        ["circle", "meteor_coordination"],
+        ["circle", "meteor_coordination", "circle_clockwise"],
         "Meteor circle",
         ["irregularity: roll angle deviations up to +-6 degree from segment start until 11:56:20 due to deep convection",
          "including 3rd METEOR overpass",
@@ -181,7 +179,7 @@ seg4c = (slice("2024-09-23T12:44:10", "2024-09-23T13:08:51"),
        )
 
 seg6 = (slice("2024-09-23T13:12:20", "2024-09-23T14:07:30"),
-        ["circle"],
+        ["circle", "circle_clockwise"],
         "circle c_mid",
         ["irregularity: deviation from circular path due to deep convection with roll angle deviations up to +-28 degree between 13:21:57 - 13:31:10"],
        )
@@ -199,7 +197,7 @@ seg8 = (slice("2024-09-23T14:26:28", "2024-09-23T14:31:32"),
 # straight_leg and circle start still with FL change
 
 seg9 = (slice("2024-09-23T14:37:34", "2024-09-23T15:32:20"),
-        ["circle"],
+        ["circle", "circle_clockwise"],
         "circle around EC track",
         ["irregularitiy: late start due to FL change, on circle roughly since 14:32:30", "irregularity: deviation from circular path due to deep convection with roll angle deviations up to +- 16 degree"]
        )
@@ -211,7 +209,7 @@ seg10 = (slice("2024-09-23T15:36:28", "2024-09-23T15:57:14"),
         )
 
 seg11 = (slice("2024-09-23T16:00:47", "2024-09-23T16:55:23"),
-         ["circle"],
+         ["circle", "circle_counterclockwise"],
          "circle south",
          ["irregularity: deviation from circular path due to deep convection in southern half, 16:15:30 - 16:18:30, with roll angle deviations up to +-30 degree.",
           "irregularity: deviation from circular path due to deep convection in northern half, from 16:47:06 until the segment ends, with roll angle deviations up to +-28 degree."]
@@ -247,7 +245,7 @@ seg16 = (slice("2024-09-23T18:03:17", "2024-09-23T18:12:36"),
         )
 
 seg17 = (slice("2024-09-23T18:15:51", "2024-09-23T19:10:36"),
-        ["circle"],
+        ["circle", "circle_clockwise"],
         "circle west",
         )
 

--- a/scripts/segmentation_HALO-20240924a.md
+++ b/scripts/segmentation_HALO-20240924a.md
@@ -15,7 +15,7 @@ jupyter:
     name: python3
 ---
 
-# Flight segmentation HALO-2024-09-24a
+# Flight segmentation HALO-20240924a
 
 ```python
 import matplotlib
@@ -167,7 +167,8 @@ sl1 = (
 
 c1 = (
     slice("2024-09-24 16:15:45", "2024-09-24 17:10:30"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
+    "first pancake circle",
     ["irregularity: deviations from circular path due to convection"],
 )
 
@@ -230,14 +231,16 @@ sl5b = (
 
 c2 = (
     slice("2024-09-24 18:56:00", "2024-09-24 20:02:00"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
+    "second pancake circle",
     ["irregularity: deviations from circlular path due to convection"
     "irregularity: ascent between 18:56:58 - 19:05:08"],
 )
 
 c3 = (
     slice("2024-09-24 20:02:00", "2024-09-24 21:06:00"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
+    "third pancake circle",
     ["irregularity: deviations from circlular path due to convection"
     "circle includes only eight drop sonde launches due to air traffic restrictions"],
 )

--- a/scripts/segmentation_HALO-20240926a.md
+++ b/scripts/segmentation_HALO-20240926a.md
@@ -15,7 +15,7 @@ jupyter:
     name: python3
 ---
 
-# Flight segmentation HALO-2024-09-26a
+# Flight segmentation HALO20240926a
 
 ```python
 import matplotlib
@@ -150,7 +150,7 @@ sl1 = (
 
 c1 = (
     slice("2024-09-26T12:26:03", "2024-09-26T13:20:10"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle_1",
 )
 
@@ -162,7 +162,7 @@ sl2 = (
 
 c2 = (
     slice("2024-09-26T13:30:59", "2024-09-26T14:24:30"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle_2",
     ["irregularity: roll angle deviation of +0.8 between 14:11:10 and 14:19:25"]
 )
@@ -181,7 +181,7 @@ sl3 = (
 
 c3 = (
     slice("2024-09-26T14:49:50", "2024-09-26T15:46:40"),
-    ["circle"],
+    ["circle", "circle_counterclockwise"],
     "circle_3",
 )
 
@@ -205,7 +205,7 @@ sl4 = (
 
 c4 = (
     slice("2024-09-26T16:06:15", "2024-09-26T17:12:00"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "circle_4",
     ["no permission to drop sondes in northern half of the circle, four sondes dropped inside circle instead"]
 )
@@ -221,7 +221,7 @@ ec1 = (
 
 c5 = (
     slice("2024-09-26T18:25:26", "2024-09-26T19:17:46"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "circle_5",
     ["irregularity: roll angle deviation of +0.8 between 18:30:42 and 18:37:22"]
 )

--- a/scripts/segmentation_HALO-20240928a.md
+++ b/scripts/segmentation_HALO-20240928a.md
@@ -168,7 +168,7 @@ sl1c = (
 
 c1 = (
     slice("2024-09-28T12:34:43", "2024-09-28T13:32:02"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "cirlce_1",
     ["irregularity: early start due to first sonde. Roll angle stable after 12:35:03."],
 )
@@ -181,7 +181,7 @@ sl2 = (
 
 c2 = (
     slice("2024-09-28T13:42:16", "2024-09-28T14:37:51"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "cirlce_2",
     ["irregularity: early start due to first sonde. Roll angle stable after 13:42:38.",
      "irregularity: few height level jumps by up to 30m and concurrent roll angle change by about 1deg",
@@ -211,7 +211,7 @@ sl3c = (
 
 c3 = (
     slice("2024-09-28T15:27:44", "2024-09-28T16:23:17"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "cirlce_3",
 )
 
@@ -223,7 +223,7 @@ sl4 = (
 
 c4 = (
     slice("2024-09-28T16:33:57", "2024-09-28T17:28:58"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "cirlce_4 with pace underpass",
     ["circle path crosses PACE track"]
 )
@@ -256,7 +256,7 @@ sl5b = (
 
 c5 = (
     slice("2024-09-28T18:15:44", "2024-09-28T19:10:07"),
-    ["circle"],
+    ["circle", "circle_clockwise"],
     "circle_5",
     ["circle path crosses PACE track"]
 )


### PR DESCRIPTION
I added an additional kind "circle_clockwise" or "circle_counterclockwise" to each circle in all flights. There was one case in HALO-20240916a where a circle was split into two half-circles with opposite circle direction. In this case, I added both directions flags to kinds and left a note in the irregularity remark that already existed in the segment.

This PR closes #101 