### PR TITLE
add sat forecasts from EUR region

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -106,7 +106,9 @@ def get_ec_track(flight_id, ds):
     takeoff, landing, _ = get_takeoff_landing(flight_id, ds)
     valid_date = takeoff.astype("datetime64[D]")
     issue_dates = [valid_date - np.timedelta64(i, 'D') for i in range(0, 6)]
-    if np.datetime64(valid_date) >= np.datetime64("2024-09-07T00:00:00"):
+    if np.datetime64(valid_date) > np.datetime64("2024-11-01T00:00:00"):
+        roi = "EUR"
+    elif np.datetime64(valid_date) >= np.datetime64("2024-09-07T00:00:00"):
         roi = "BARBADOS" # region of interest
     else:
         roi = "CAPE_VERDE"


### PR DESCRIPTION
This PR adds a criterion to use EUR as the region of interest in the `get_ec_track` function. This enables to load the EC tracks for the November flights.