### PR TITLE
Add op airport to get_takeoff_landing()

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -277,7 +277,7 @@ def get_takeoff_landing(flight_id, ds):
         ):
         airport_takeoff_wgs84 = 684   #Memmingen
     elif ds.time[0].values > np.datetime64("2024-11-01T00:00:00"):                       # All other November flights
-        airport_takeoff_wgs84 = 638   #Oberpfaffenhofen
+        airport_takeoff_wgs84 = 635   #Oberpfaffenhofen
     elif (ds.time[0].values >= np.datetime64("2024-08-10T00:00:00") and                  
           ds.time[0].values < np.datetime64("2024-09-07T00:00:00")
          ):
@@ -292,8 +292,8 @@ def get_takeoff_landing(flight_id, ds):
           ds.time[-1].values < np.datetime64("2024-09-29T00:00:00")
          ):
         airport_landing_wgs84 = 9     #Barbados
-    elif ds.time[-1].values > np.datetime64("2024-11-01T00:00:00"):# and "a" in flight_id:    # All other November flights
-        airport_landing_wgs84 = 638   #Oberpfaffenhofen
+    elif ds.time[-1].values > np.datetime64("2024-11-01T00:00:00"):                     # All other November flights
+        airport_landing_wgs84 = 635   #Oberpfaffenhofen
     elif ds.time[-1].values >= np.datetime64("2024-09-30T00:00:00") and ds.time[-1].values <= np.datetime64("2024-09-30T23:59:59"):                          # Transfer back from Barbados
         airport_landing_wgs84 = 684   #Memmingen
     

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -298,7 +298,7 @@ def get_takeoff_landing(flight_id, ds):
         airport_landing_wgs84 = 684   #Memmingen
     
     takeoff = ds["time"].where(ds.alt > airport_takeoff_wgs84, drop=True)[0].values
-    landing = ds["time"].where(ds.alt > airport_landing_wgs84, drop=True)[-1].values
+    landing = ds["time"].where((ds.alt <= airport_landing_wgs84) & (ds.time > takeoff), drop=True)[0].values
     duration = (landing - takeoff).astype("timedelta64[m]").astype(int)
     return takeoff, landing, duration
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -292,10 +292,10 @@ def get_takeoff_landing(flight_id, ds):
           ds.time[-1].values < np.datetime64("2024-09-29T00:00:00")
          ):
         airport_landing_wgs84 = 9     #Barbados
-    elif ds.time[-1].values > np.datetime64("2024-11-01T00:00:00") and "a" in flight_id:                       # All other November flights
-        airport_landing_wgs84 = 634   #Oberpfaffenhofen
-    elif ds.time[-1].values >= np.datetime64("2024-09-29T00:00:00"):                                           # Two November flights and transfer back from Barbados
-        airport_landing_wgs84 = 681   #Memmingen
+    elif ds.time[-1].values > np.datetime64("2024-11-01T00:00:00"):# and "a" in flight_id:    # All other November flights
+        airport_landing_wgs84 = 635   #Oberpfaffenhofen
+    elif ds.time[-1].values >= np.datetime64("2024-09-30T00:00:00") and ds.time[-1].values <= np.datetime64("2024-09-30T23:59:59"):                          # Transfer back from Barbados
+        airport_landing_wgs84 = 684   #Memmingen
     
     takeoff = ds["time"].where(ds.alt > airport_takeoff_wgs84, drop=True)[0].values
     landing = ds["time"].where(ds.alt > airport_landing_wgs84, drop=True)[-1].values

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -272,9 +272,13 @@ def get_takeoff_landing(flight_id, ds):
     """
     import numpy as np
     # takeoff airport
-    if ds.time[0].values < np.datetime64("2024-08-10T00:00:00"):
+    if (ds.time[0].values < np.datetime64("2024-08-10T00:00:00") or                     # Transfer flight to Sal
+        (ds.time[0].values > np.datetime64("2024-11-01T00:00:00") and "b" in flight_id) # Two November flights
+        ):
         airport_takeoff_wgs84 = 681   #Memmingen
-    elif (ds.time[0].values >= np.datetime64("2024-08-10T00:00:00") and
+    elif ds.time[0].values > np.datetime64("2024-11-01T00:00:00"):                       # All other November flights
+        airport_landing_wgs84 = 593   #Oberpfaffenhofen
+    elif (ds.time[0].values >= np.datetime64("2024-08-10T00:00:00") and                  
           ds.time[0].values < np.datetime64("2024-09-07T00:00:00")
          ):
         airport_takeoff_wgs84 = 90    #Sal
@@ -288,7 +292,9 @@ def get_takeoff_landing(flight_id, ds):
           ds.time[-1].values < np.datetime64("2024-09-29T00:00:00")
          ):
         airport_landing_wgs84 = 9     #Barbados
-    elif ds.time[-1].values >= np.datetime64("2024-09-29T00:00:00"):
+    elif ds.time[-1].values > np.datetime64("2024-11-01T00:00:00") and "a" in flight_id:                       # All other November flights
+        airport_landing_wgs84 = 593   #Oberpfaffenhofen
+    elif ds.time[-1].values >= np.datetime64("2024-09-29T00:00:00"):                                           # Two November flights and transfer back from Barbados
         airport_landing_wgs84 = 681   #Memmingen
     
     takeoff = ds["time"].where(ds.alt > airport_takeoff_wgs84, drop=True)[0].values

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -298,7 +298,7 @@ def get_takeoff_landing(flight_id, ds):
         airport_landing_wgs84 = 681   #Memmingen
     
     takeoff = ds["time"].where(ds.alt > airport_takeoff_wgs84, drop=True)[0].values
-    if not ds["time"].where((ds.alt <= airport_landing_wgs84) & (ds.time > takeoff), drop=True): # handle exception of missing BAHAMAS data at end of flight
+    if len(ds["time"].where((ds.alt <= airport_landing_wgs84) & (ds.time > takeoff), drop=True)) == 0: # handle exception of missing BAHAMAS data at end of flight
         landing = ds["time"][-1].values
     else:
         landing = ds["time"].where((ds.alt <= airport_landing_wgs84) & (ds.time > takeoff), drop=True)[0].values

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -277,7 +277,7 @@ def get_takeoff_landing(flight_id, ds):
         ):
         airport_takeoff_wgs84 = 681   #Memmingen
     elif ds.time[0].values > np.datetime64("2024-11-01T00:00:00"):                       # All other November flights
-        airport_landing_wgs84 = 593   #Oberpfaffenhofen
+        airport_takeoff_wgs84 = 634   #Oberpfaffenhofen
     elif (ds.time[0].values >= np.datetime64("2024-08-10T00:00:00") and                  
           ds.time[0].values < np.datetime64("2024-09-07T00:00:00")
          ):
@@ -293,7 +293,7 @@ def get_takeoff_landing(flight_id, ds):
          ):
         airport_landing_wgs84 = 9     #Barbados
     elif ds.time[-1].values > np.datetime64("2024-11-01T00:00:00") and "a" in flight_id:                       # All other November flights
-        airport_landing_wgs84 = 593   #Oberpfaffenhofen
+        airport_landing_wgs84 = 634   #Oberpfaffenhofen
     elif ds.time[-1].values >= np.datetime64("2024-09-29T00:00:00"):                                           # Two November flights and transfer back from Barbados
         airport_landing_wgs84 = 681   #Memmingen
     

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -275,9 +275,9 @@ def get_takeoff_landing(flight_id, ds):
     if (ds.time[0].values < np.datetime64("2024-08-10T00:00:00") or                     # Transfer flight to Sal
         (ds.time[0].values > np.datetime64("2024-11-01T00:00:00") and "b" in flight_id) # Two November flights
         ):
-        airport_takeoff_wgs84 = 681   #Memmingen
+        airport_takeoff_wgs84 = 684   #Memmingen
     elif ds.time[0].values > np.datetime64("2024-11-01T00:00:00"):                       # All other November flights
-        airport_takeoff_wgs84 = 634   #Oberpfaffenhofen
+        airport_takeoff_wgs84 = 635   #Oberpfaffenhofen
     elif (ds.time[0].values >= np.datetime64("2024-08-10T00:00:00") and                  
           ds.time[0].values < np.datetime64("2024-09-07T00:00:00")
          ):

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -275,9 +275,9 @@ def get_takeoff_landing(flight_id, ds):
     if (ds.time[0].values < np.datetime64("2024-08-10T00:00:00") or                     # Transfer flight to Sal
         (ds.time[0].values > np.datetime64("2024-11-01T00:00:00") and "b" in flight_id) # Two November flights
         ):
-        airport_takeoff_wgs84 = 684   #Memmingen
+        airport_takeoff_wgs84 = 681   #Memmingen
     elif ds.time[0].values > np.datetime64("2024-11-01T00:00:00"):                       # All other November flights
-        airport_takeoff_wgs84 = 635   #Oberpfaffenhofen
+        airport_takeoff_wgs84 = 630   #Oberpfaffenhofen
     elif (ds.time[0].values >= np.datetime64("2024-08-10T00:00:00") and                  
           ds.time[0].values < np.datetime64("2024-09-07T00:00:00")
          ):
@@ -293,9 +293,9 @@ def get_takeoff_landing(flight_id, ds):
          ):
         airport_landing_wgs84 = 9     #Barbados
     elif ds.time[-1].values > np.datetime64("2024-11-01T00:00:00"):                     # All other November flights
-        airport_landing_wgs84 = 635   #Oberpfaffenhofen
+        airport_landing_wgs84 = 630   #Oberpfaffenhofen
     elif ds.time[-1].values >= np.datetime64("2024-09-30T00:00:00") and ds.time[-1].values <= np.datetime64("2024-09-30T23:59:59"):                          # Transfer back from Barbados
-        airport_landing_wgs84 = 684   #Memmingen
+        airport_landing_wgs84 = 681   #Memmingen
     
     takeoff = ds["time"].where(ds.alt > airport_takeoff_wgs84, drop=True)[0].values
     landing = ds["time"].where((ds.alt <= airport_landing_wgs84) & (ds.time > takeoff), drop=True)[0].values

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -277,7 +277,7 @@ def get_takeoff_landing(flight_id, ds):
         ):
         airport_takeoff_wgs84 = 684   #Memmingen
     elif ds.time[0].values > np.datetime64("2024-11-01T00:00:00"):                       # All other November flights
-        airport_takeoff_wgs84 = 635   #Oberpfaffenhofen
+        airport_takeoff_wgs84 = 636   #Oberpfaffenhofen
     elif (ds.time[0].values >= np.datetime64("2024-08-10T00:00:00") and                  
           ds.time[0].values < np.datetime64("2024-09-07T00:00:00")
          ):
@@ -293,7 +293,7 @@ def get_takeoff_landing(flight_id, ds):
          ):
         airport_landing_wgs84 = 9     #Barbados
     elif ds.time[-1].values > np.datetime64("2024-11-01T00:00:00"):# and "a" in flight_id:    # All other November flights
-        airport_landing_wgs84 = 635   #Oberpfaffenhofen
+        airport_landing_wgs84 = 636   #Oberpfaffenhofen
     elif ds.time[-1].values >= np.datetime64("2024-09-30T00:00:00") and ds.time[-1].values <= np.datetime64("2024-09-30T23:59:59"):                          # Transfer back from Barbados
         airport_landing_wgs84 = 684   #Memmingen
     

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -277,7 +277,7 @@ def get_takeoff_landing(flight_id, ds):
         ):
         airport_takeoff_wgs84 = 684   #Memmingen
     elif ds.time[0].values > np.datetime64("2024-11-01T00:00:00"):                       # All other November flights
-        airport_takeoff_wgs84 = 636   #Oberpfaffenhofen
+        airport_takeoff_wgs84 = 638   #Oberpfaffenhofen
     elif (ds.time[0].values >= np.datetime64("2024-08-10T00:00:00") and                  
           ds.time[0].values < np.datetime64("2024-09-07T00:00:00")
          ):
@@ -293,7 +293,7 @@ def get_takeoff_landing(flight_id, ds):
          ):
         airport_landing_wgs84 = 9     #Barbados
     elif ds.time[-1].values > np.datetime64("2024-11-01T00:00:00"):# and "a" in flight_id:    # All other November flights
-        airport_landing_wgs84 = 636   #Oberpfaffenhofen
+        airport_landing_wgs84 = 638   #Oberpfaffenhofen
     elif ds.time[-1].values >= np.datetime64("2024-09-30T00:00:00") and ds.time[-1].values <= np.datetime64("2024-09-30T23:59:59"):                          # Transfer back from Barbados
         airport_landing_wgs84 = 684   #Memmingen
     

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -298,7 +298,10 @@ def get_takeoff_landing(flight_id, ds):
         airport_landing_wgs84 = 681   #Memmingen
     
     takeoff = ds["time"].where(ds.alt > airport_takeoff_wgs84, drop=True)[0].values
-    landing = ds["time"].where((ds.alt <= airport_landing_wgs84) & (ds.time > takeoff), drop=True)[0].values
+    if not ds["time"].where((ds.alt <= airport_landing_wgs84) & (ds.time > takeoff), drop=True): # handle exception of missing BAHAMAS data at end of flight
+        landing = ds["time"][-1].values
+    else:
+        landing = ds["time"].where((ds.alt <= airport_landing_wgs84) & (ds.time > takeoff), drop=True)[0].values
     duration = (landing - takeoff).astype("timedelta64[m]").astype(int)
     return takeoff, landing, duration
 


### PR DESCRIPTION
To determine takeoff/landing times for the November flights, I added the Oberpfaffenhofen airport (OP) altitude to the `get_takeoff_landing` function and made some further changes to the criteria for takeoff and landing times. The new version:

- can handle flights that take takeoff and land in OP
- can handle flights that take off in Memmingen and land in OP (those that have a "b" in their flight id)
- defines the landing time as the first instance after takeoff at which the plane reaches the airport altitude (rather than the last instance at which it is above the airport altitude)

The last modification was necessary because HALO experienced rather large bumps after touchdown in OP so that the previous algorithm consistently determined a too late landing time.