### PR TITLE
Add Meteorologisches Institut Muenchen (MIM) to target_event function

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ For the first version of the segmentation of HALO research flights, one or more 
 | ec_underpass | events | assigned to events where the aircraft flew as close as possible under the EarthCARE satellite |
 | meteor_coordination | segments | assigned to segments during which HALO flew around or in the vicinity of the Meteor research vessel |
 | meteor_overpass | events | assigned to events where the aircraft flew roughly over the Meteor research vessel |
+| mim_overpass | events | assigned to events where the aircraft flew roughly over the Meteorological Institute in Munich |
 | pace_track | segments | assigned to straight legs during which the aircraft followed the PACE track; note that measurements taken in other segments may also be colocated with PACE due to the satellite's wide swath. |
 | pace_underpass | events | assigned to events where the aircraft flew as close as possible under the PACE satellite. |
 | radar_calibration_dive | segments | three consecutive stepwise descents with a total altitude decrease of about 1km within about 2.5min, performed during a descending straight leg |

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -171,8 +171,13 @@ def target_event(ds, target=None, target_lat=None, target_lon=None,
         target_name = "CVAO overpass"
         target_kinds = ["cvao_overpass"]
 
+    elif target=="MIM":
+        target_lat, target_lon = 48.14778, 11.57333
+        target_name = "MIM overpass"
+        target_kinds = ["mim_overpass"]
+
     elif (target is None) and ((target_lat is None) or (target_lon is None)):
-        print("You need to specify either a target, i.e. BCO or CVAO, or a target_lat and target_lon")
+        print("You need to specify either a target, i.e. BCO, CVAO, MIM or a target_lat and target_lon")
         return
     else:
         target_name = "target meeting point"


### PR DESCRIPTION
For the November flights, I added the target `MIM` and its coordinates to the `target_event` function. The MIM was one of the ground stations that were deliberately overpassed by HALO.