### PR TITLE
Update circles

### DIFF
--- a/scripts/segmentation_HALO-20240809b.md
+++ b/scripts/segmentation_HALO-20240809b.md
@@ -284,6 +284,29 @@ yaml.dump(to_yaml(platform, flight_id, ds, segments, events),
           sort_keys=False)
 ```
 
+## Import YAML and test it
+
+```python
+flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
+```
+
+```python
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+```python
+fig, ax = plt.subplots()
+
+for k, c in zip(['straight_leg', 'circle', 'radar_calibration'], ["C0", "C1", "C2"]):
+    for s in flight["segments"]:
+        if k in s["kinds"]:
+            t = slice(s["start"], s["end"])
+            ax.plot(ds.lon.sel(time=t), ds.lat.sel(time=t), c=c, label=s["name"])
+ax.set_xlabel("longitude / °")
+ax.set_ylabel("latitude / °");
+```
+
 ```python
 
 ```

--- a/scripts/segmentation_HALO-20240811a.md
+++ b/scripts/segmentation_HALO-20240811a.md
@@ -201,7 +201,7 @@ sl3 = (
 )
 
 catr = (
-    slice("2024-08-11T19:16:38", "2024-08-11T19:58:01"),
+    slice("2024-08-11T19:16:38", "2024-08-11T19:57:20"),
     ["circle", "atr_coordination", "circle_clockwise"], 
     "ATR_circle", 
     [],

--- a/scripts/segmentation_HALO-20240811a.md
+++ b/scripts/segmentation_HALO-20240811a.md
@@ -300,6 +300,25 @@ yaml.dump(to_yaml(platform, flight_id, ds, segments, events),
           sort_keys=False)
 ```
 
-```python
+## Import YAML and test it
 
+```python
+flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
+```
+
+```python
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+```python
+fig, ax = plt.subplots()
+
+for k, c in zip(['straight_leg', 'circle', 'radar_calibration'], ["C0", "C1", "C2"]):
+    for s in flight["segments"]:
+        if k in s["kinds"]:
+            t = slice(s["start"], s["end"])
+            ax.plot(ds.lon.sel(time=t), ds.lat.sel(time=t), c=c, label=s["name"])
+ax.set_xlabel("longitude / °")
+ax.set_ylabel("latitude / °");
 ```

--- a/scripts/segmentation_HALO-20240811a.md
+++ b/scripts/segmentation_HALO-20240811a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240813a.md
+++ b/scripts/segmentation_HALO-20240813a.md
@@ -373,7 +373,8 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240813a.md
+++ b/scripts/segmentation_HALO-20240813a.md
@@ -46,7 +46,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240816a.md
+++ b/scripts/segmentation_HALO-20240816a.md
@@ -311,6 +311,29 @@ yaml.dump(to_yaml(platform, flight_id, ds, segments, events),
           sort_keys=False)
 ```
 
+## Import YAML and test it
+
+```python
+flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
+```
+
+```python
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+```python
+fig, ax = plt.subplots()
+
+for k, c in zip(['straight_leg', 'circle', ], ["C0", "C1"]):
+    for s in flight["segments"]:
+        if k in s["kinds"]:
+            t = slice(s["start"], s["end"])
+            ax.plot(ds.lon.sel(time=t), ds.lat.sel(time=t), c=c, label=s["name"])
+ax.set_xlabel("longitude / °")
+ax.set_ylabel("latitude / °");
+```
+
 ```python
 
 ```

--- a/scripts/segmentation_HALO-20240816a.md
+++ b/scripts/segmentation_HALO-20240816a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240818a.md
+++ b/scripts/segmentation_HALO-20240818a.md
@@ -170,6 +170,7 @@ c2 = (
     slice("2024-08-18T12:53:12", "2024-08-18T13:47:18"),
     ["circle", "circle_clockwise"], "circle_mid",
     ["irregularity: turbulence"],
+    [str(ds_drops.sel(time="2024-08-18T12:41:27").sonde_id.values)],
 )
 
 ec3 = (
@@ -180,7 +181,9 @@ ec3 = (
 
 c3 = (
     slice("2024-08-18T14:28:14", "2024-08-18T15:24:08"),
-    ["circle", "circle_clockwise"], "circle_south", [],
+    ["circle", "circle_clockwise"], "circle_south",
+    [],
+    [str(ds_drops.sel(time="2024-08-18T15:34:17").sonde_id.values)],
 )
 
 ec4 = (

--- a/scripts/segmentation_HALO-20240818a.md
+++ b/scripts/segmentation_HALO-20240818a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240818a.md
+++ b/scripts/segmentation_HALO-20240818a.md
@@ -317,6 +317,42 @@ yaml.dump(to_yaml(platform, flight_id, ds, segments, events),
           sort_keys=False)
 ```
 
-```python
+## Import YAML and test it
 
+```python
+flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
+```
+
+```python
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+Print circle segments with extra sondes
+
+```python
+[s for s in flight["segments"] if ("circle" in s["kinds"] and "extra_sondes" in s.keys())]
+```
+
+Plot all sondes related to a circle segment indetified by it's id
+
+```python
+seg = [s for s in flight["segments"] if s["segment_id"]=="HALO-20240818a_f5f5"][0]
+plt.scatter(ds_drops.sel(time=slice(seg["start"], seg["end"])).lon,
+         ds_drops.sel(time=slice(seg["start"], seg["end"])).lat)
+if "extra_sondes" in seg.keys():
+    plt.scatter(ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lon,
+                ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lat)
+```
+
+```python
+fig, ax = plt.subplots()
+
+for k, c in zip(['straight_leg', 'circle', ], ["C0", "C1"]):
+    for s in flight["segments"]:
+        if k in s["kinds"]:
+            t = slice(s["start"], s["end"])
+            ax.plot(ds.lon.sel(time=t), ds.lat.sel(time=t), c=c, label=s["name"])
+ax.set_xlabel("longitude / °")
+ax.set_ylabel("latitude / °");
 ```

--- a/scripts/segmentation_HALO-20240821a.md
+++ b/scripts/segmentation_HALO-20240821a.md
@@ -330,6 +330,29 @@ yaml.dump(to_yaml(platform, flight_id, ds, segments, events),
           sort_keys=False)
 ```
 
+## Import YAML and test it
+
+```python
+flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
+```
+
+```python
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+```python
+fig, ax = plt.subplots()
+
+for k, c in zip(['straight_leg', 'circle', ], ["C0", "C1"]):
+    for s in flight["segments"]:
+        if k in s["kinds"]:
+            t = slice(s["start"], s["end"])
+            ax.plot(ds.lon.sel(time=t), ds.lat.sel(time=t), c=c, label=s["name"])
+ax.set_xlabel("longitude / °")
+ax.set_ylabel("latitude / °");
+```
+
 ```python
 
 ```

--- a/scripts/segmentation_HALO-20240821a.md
+++ b/scripts/segmentation_HALO-20240821a.md
@@ -53,7 +53,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240822a.md
+++ b/scripts/segmentation_HALO-20240822a.md
@@ -373,6 +373,29 @@ yaml.dump(to_yaml(platform, flight_id, ds, segments, events),
           sort_keys=False)
 ```
 
+## Import YAML and test it
+
+```python
+flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
+```
+
+```python
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+```python
+fig, ax = plt.subplots()
+
+for k, c in zip(['straight_leg', 'circle', ], ["C0", "C1"]):
+    for s in flight["segments"]:
+        if k in s["kinds"]:
+            t = slice(s["start"], s["end"])
+            ax.plot(ds.lon.sel(time=t), ds.lat.sel(time=t), c=c, label=s["name"])
+ax.set_xlabel("longitude / °")
+ax.set_ylabel("latitude / °");
+```
+
 ```python
 
 ```

--- a/scripts/segmentation_HALO-20240822a.md
+++ b/scripts/segmentation_HALO-20240822a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240825a.md
+++ b/scripts/segmentation_HALO-20240825a.md
@@ -181,7 +181,8 @@ seg7 = (
     slice("2024-08-25T11:56:28", "2024-08-25T12:52:34"),
     ["circle", "circle_counterclockwise"],
     "southern circle",
-    []
+    [],
+    [str(ds_drops.sel(time="2024-08-25T13:02:54").sonde_id.values)],
 )
 
 seg8 = (

--- a/scripts/segmentation_HALO-20240825a.md
+++ b/scripts/segmentation_HALO-20240825a.md
@@ -383,6 +383,46 @@ yaml.dump(to_yaml(platform, flight_id, ds, segments, events),
           sort_keys=False)
 ```
 
+## Import YAML and test it
+
+```python
+flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
+```
+
+```python
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+Print circle segments
+
+```python
+[s for s in flight["segments"] if "circle" in s["kinds"]]
+```
+
+Plot all sondes related to a circle segment indetified by it's id
+
+```python
+seg = [s for s in flight["segments"] if s["segment_id"]=="HALO-20240825a_7edc"][0]
+plt.scatter(ds_drops.sel(time=slice(seg["start"], seg["end"])).lon,
+         ds_drops.sel(time=slice(seg["start"], seg["end"])).lat)
+if "extra_sondes" in seg.keys():
+    plt.scatter(ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lon,
+                ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lat)
+```
+
+```python
+fig, ax = plt.subplots()
+
+for k, c in zip(['straight_leg', 'circle', ], ["C0", "C1"]):
+    for s in flight["segments"]:
+        if k in s["kinds"]:
+            t = slice(s["start"], s["end"])
+            ax.plot(ds.lon.sel(time=t), ds.lat.sel(time=t), c=c, label=s["name"])
+ax.set_xlabel("longitude / °")
+ax.set_ylabel("latitude / °");
+```
+
 ```python
 
 ```

--- a/scripts/segmentation_HALO-20240825a.md
+++ b/scripts/segmentation_HALO-20240825a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240827a.md
+++ b/scripts/segmentation_HALO-20240827a.md
@@ -419,7 +419,8 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240827a.md
+++ b/scripts/segmentation_HALO-20240827a.md
@@ -47,7 +47,9 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest") \
+             .swap_dims({"sonde_id": "time"}) \
+             .sortby("time")
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240829a.md
+++ b/scripts/segmentation_HALO-20240829a.md
@@ -218,7 +218,7 @@ seg12 = (
 )
 
 seg13 = (
-    slice("2024-08-29T17:39:30", "2024-08-29T18:40:31"),
+    slice("2024-08-29T17:41:10", "2024-08-29T18:40:31"),#17:39:30
     ["circle", "circle_counterclockwise"],
     "northern circle",
 )

--- a/scripts/segmentation_HALO-20240829a.md
+++ b/scripts/segmentation_HALO-20240829a.md
@@ -380,7 +380,8 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240829a.md
+++ b/scripts/segmentation_HALO-20240829a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240831a.md
+++ b/scripts/segmentation_HALO-20240831a.md
@@ -50,7 +50,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240831a.md
+++ b/scripts/segmentation_HALO-20240831a.md
@@ -391,7 +391,25 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+Print circle segments with extra sondes
+
+```python
+[s for s in flight["segments"] if ("circle" in s["kinds"] and "extra_sondes" in s.keys())]
+```
+
+Plot all sondes related to a circle segment indetified by it's id
+
+```python
+seg = [s for s in flight["segments"] if s["segment_id"]=="HALO-20240831a_33ff"][0]
+plt.scatter(ds_drops.sel(time=slice(seg["start"], seg["end"])).lon,
+         ds_drops.sel(time=slice(seg["start"], seg["end"])).lat)
+if "extra_sondes" in seg.keys():
+    plt.scatter(ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lon,
+                ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lat)
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240831a.md
+++ b/scripts/segmentation_HALO-20240831a.md
@@ -227,7 +227,8 @@ seg13 = (
     slice("2024-08-31T12:52:25", "2024-08-31T13:48:01"),
     ["circle", "circle_counterclockwise"],
     "middle circle",
-    ["irregularity: turbulence with up to plus/minus 4.5 degree roll angle deviation"]
+    ["irregularity: turbulence with up to plus/minus 4.5 degree roll angle deviation"],
+    [str(ds_drops.sel(time="2024-08-31T14:05:21").sonde_id.values)],
 )
 
 seg14 = (

--- a/scripts/segmentation_HALO-20240903a.md
+++ b/scripts/segmentation_HALO-20240903a.md
@@ -221,13 +221,13 @@ sl5 = (
 
 catr1 = (
     slice("2024-09-03 19:01:06", "2024-09-03 19:06:37"),
-    ["circle", "atr_coordination", "circle_counterclockwise"],
+    ["atr_coordination"],
     "quarter_ATR_circle", ["quarter ATR circle: northeastern quadrant"],
 )
 
 sl6 = (
     slice("2024-09-03T19:14:00", "2024-09-03T19:22:58"),
-    ["straight_leg"], "southward_crossing_catr",
+    ["straight_leg", "atr_coordination"], "southward_crossing_catr",
     ["Crossing ATR circle along its full latitudinal extent"],
 )
     

--- a/scripts/segmentation_HALO-20240903a.md
+++ b/scripts/segmentation_HALO-20240903a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240903a.md
+++ b/scripts/segmentation_HALO-20240903a.md
@@ -341,3 +341,30 @@ yaml.dump(to_yaml(platform, flight_id, ds, segments, events),
           open(f"../flight_segment_files/{flight_id}.yaml", "w"),
           sort_keys=False)
 ```
+
+## Import YAML and test it
+
+```python
+flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
+```
+
+```python
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+```python
+fig, ax = plt.subplots()
+
+for k, c in zip(['straight_leg', 'circle', ], ["C0", "C1"]):
+    for s in flight["segments"]:
+        if k in s["kinds"]:
+            t = slice(s["start"], s["end"])
+            ax.plot(ds.lon.sel(time=t), ds.lat.sel(time=t), c=c, label=s["name"])
+ax.set_xlabel("longitude / °")
+ax.set_ylabel("latitude / °");
+```
+
+```python
+
+```

--- a/scripts/segmentation_HALO-20240906a.md
+++ b/scripts/segmentation_HALO-20240906a.md
@@ -342,7 +342,8 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240906a.md
+++ b/scripts/segmentation_HALO-20240906a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240907a.md
+++ b/scripts/segmentation_HALO-20240907a.md
@@ -368,7 +368,25 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+Print circle segments with extra sondes
+
+```python
+[s for s in flight["segments"] if ("circle" in s["kinds"] and "extra_sondes" in s.keys())]
+```
+
+Plot all sondes related to a circle segment indetified by it's id
+
+```python
+seg = [s for s in flight["segments"] if s["segment_id"]=="HALO-20240907a_0290"][0]
+plt.scatter(ds_drops.sel(time=slice(seg["start"], seg["end"])).lon,
+         ds_drops.sel(time=slice(seg["start"], seg["end"])).lat)
+if "extra_sondes" in seg.keys():
+    plt.scatter(ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lon,
+                ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lat)
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240907a.md
+++ b/scripts/segmentation_HALO-20240907a.md
@@ -46,7 +46,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240907a.md
+++ b/scripts/segmentation_HALO-20240907a.md
@@ -193,7 +193,12 @@ seg9 = (
     slice("2024-09-07T15:59:33", "2024-09-07T17:01:03"),
     ["circle", "circle_counterclockwise"],
     "middle circle",
-    ["irregularities: permission denied for some sondes which were then dropped on straight leg through circle instead"]
+    ["irregularities: permission denied for some sondes which were then dropped on straight leg through circle instead"],
+    [str(ds_drops.sel(time="2024-09-07T17:11:21").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-07T17:15:01").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-07T17:18:53").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-07T17:19:36").sonde_id.values)],
+
 )
 
 seg10 = (

--- a/scripts/segmentation_HALO-20240909a.md
+++ b/scripts/segmentation_HALO-20240909a.md
@@ -322,7 +322,8 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240909a.md
+++ b/scripts/segmentation_HALO-20240909a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240912a.md
+++ b/scripts/segmentation_HALO-20240912a.md
@@ -182,9 +182,10 @@ seg6 = (
 )
 
 seg7 = (
-    slice("2024-09-12T14:18:20", "2024-09-12T15:10:37"),
+    slice("2024-09-12T14:14:40", "2024-09-12T15:10:37"),
     ["circle", "circle_counterclockwise"],
     "north-eastern circle",
+    ["early start of circle due to dropsonde", "stable roll angle after 14:18:20"],
 )
 
 seg8 = (

--- a/scripts/segmentation_HALO-20240912a.md
+++ b/scripts/segmentation_HALO-20240912a.md
@@ -54,7 +54,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240912a.md
+++ b/scripts/segmentation_HALO-20240912a.md
@@ -349,7 +349,8 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240914a.md
+++ b/scripts/segmentation_HALO-20240914a.md
@@ -315,7 +315,25 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+Print circle segments with extra sondes
+
+```python
+[s for s in flight["segments"] if ("circle" in s["kinds"] and "extra_sondes" in s.keys())]
+```
+
+Plot all sondes related to a circle segment indetified by it's id
+
+```python
+seg = [s for s in flight["segments"] if s["segment_id"]=="HALO-20240914a_1049"][0]
+plt.scatter(ds_drops.sel(time=slice(seg["start"], seg["end"])).lon,
+         ds_drops.sel(time=slice(seg["start"], seg["end"])).lat)
+if "extra_sondes" in seg.keys():
+    plt.scatter(ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lon,
+                ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lat)
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240914a.md
+++ b/scripts/segmentation_HALO-20240914a.md
@@ -188,6 +188,8 @@ c2 = (
     slice("2024-09-14T14:52:41", "2024-09-14T15:50:44"),
     ["circle", "circle_clockwise"],
     "circle 2",
+    [],
+    [str(ds_drops.sel(time="2024-09-14T14:35:56").sonde_id.values)],
 )
 
 c3 = (

--- a/scripts/segmentation_HALO-20240914a.md
+++ b/scripts/segmentation_HALO-20240914a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240916a.md
+++ b/scripts/segmentation_HALO-20240916a.md
@@ -340,7 +340,25 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+Print circle segments with extra sondes
+
+```python
+[s for s in flight["segments"] if ("circle" in s["kinds"] and "extra_sondes" in s.keys())]
+```
+
+Plot all sondes related to a circle segment indetified by it's id
+
+```python
+seg = [s for s in flight["segments"] if s["segment_id"]=="HALO-20240916a_bce8"][0]
+plt.scatter(ds_drops.sel(time=slice(seg["start"], seg["end"])).lon,
+         ds_drops.sel(time=slice(seg["start"], seg["end"])).lat)
+if "extra_sondes" in seg.keys():
+    plt.scatter(ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lon,
+                ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lat)
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240916a.md
+++ b/scripts/segmentation_HALO-20240916a.md
@@ -173,6 +173,7 @@ c2 = (
     ["circle", "circle_counterclockwise", "circle_clockwise"],
     "circle_south",
     ["irregularity: two half circles with straight leg in between, first half counterclockwise, second half clockwise"],
+    [str(ds_drops.sel(time="2024-09-16T16:01:56").sonde_id.values)],
 )
 
 sl3b = (

--- a/scripts/segmentation_HALO-20240916a.md
+++ b/scripts/segmentation_HALO-20240916a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240919a.md
+++ b/scripts/segmentation_HALO-20240919a.md
@@ -170,13 +170,15 @@ c2 = (
     slice("2024-09-19 13:58:32", "2024-09-19 14:53:20"),
     ["circle", "circle_counterclockwise", "meteor_coordination"],
     "circle_2",
+    [],
+    [str(ds_drops.sel(time="2024-09-19T13:46:42").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-19T13:52:12").sonde_id.values)],
 )
 
 catr = (
     slice("2024-09-19 15:03:25", "2024-09-19 15:33:36"),
     ["circle", "circle_counterclockwise"],
     "small circle",
-    [],
     ["smaller radius due to time limitations"],
 )
 
@@ -204,6 +206,11 @@ c4 = (
     slice("2024-09-19 16:30:13", "2024-09-19 17:25:15"),
     ["circle", "circle_clockwise"],
     "circle_4",
+    [],
+    [str(ds_drops.sel(time="2024-09-19T16:10:29").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-19T16:19:36").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-19T17:34:14").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-19T17:41:46").sonde_id.values)],
 )
 
 ec1 = (
@@ -223,6 +230,9 @@ c5 = (
     slice("2024-09-19 18:04:55", "2024-09-19 19:04:15"),
     ["circle", "circle_clockwise"],
     "circle_5",
+    [],
+    [str(ds_drops.sel(time="2024-09-19T19:11:11").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-19T19:17:21").sonde_id.values)],
 )
 
 sl4 = (

--- a/scripts/segmentation_HALO-20240919a.md
+++ b/scripts/segmentation_HALO-20240919a.md
@@ -364,7 +364,25 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+Print circle segments with extra sondes
+
+```python
+[s for s in flight["segments"] if ("circle" in s["kinds"] and "extra_sondes" in s.keys())]
+```
+
+Plot all sondes related to a circle segment indetified by it's id
+
+```python
+seg = [s for s in flight["segments"] if s["segment_id"]=="HALO-20240919a_69a2"][0]
+plt.scatter(ds_drops.sel(time=slice(seg["start"], seg["end"])).lon,
+         ds_drops.sel(time=slice(seg["start"], seg["end"])).lat)
+if "extra_sondes" in seg.keys():
+    plt.scatter(ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lon,
+                ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lat)
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240919a.md
+++ b/scripts/segmentation_HALO-20240919a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240921a.md
+++ b/scripts/segmentation_HALO-20240921a.md
@@ -195,7 +195,7 @@ c2 = (
 )
 
 c3 = (
-    slice("2024-09-21 14:52:00", "2024-09-21 15:54:00"),
+    slice("2024-09-21 14:52:00", "2024-09-21 15:51:50"),
     ["circle", "circle_counterclockwise"],
     "circle_3",
     ["irregularity: deviation from circular path 15:10:13 - 15:16:05 with roll angle deviation up tp +-19.2 deg"],

--- a/scripts/segmentation_HALO-20240921a.md
+++ b/scripts/segmentation_HALO-20240921a.md
@@ -146,6 +146,7 @@ c1 = (
     ["circle", "circle_counterclockwise", "meteor_coordination"],
     "circle_1",
     ["irregularity: ascent until 11:54:12"],
+    [str(ds_drops.sel(time="2024-09-21T13:02:23").sonde_id.values)],
 )
 
 sl1a = (

--- a/scripts/segmentation_HALO-20240921a.md
+++ b/scripts/segmentation_HALO-20240921a.md
@@ -372,3 +372,43 @@ yaml.dump(to_yaml(platform, flight_id, ds, segments, events),
           open(f"../flight_segment_files/{flight_id}.yaml", "w"),
           sort_keys=False)
 ```
+
+## Import YAML and test it
+
+```python
+flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
+```
+
+```python
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+Print circle segments with extra sondes
+
+```python
+[s for s in flight["segments"] if ("circle" in s["kinds"] and "extra_sondes" in s.keys())]
+```
+
+Plot all sondes related to a circle segment indetified by it's id
+
+```python
+seg = [s for s in flight["segments"] if s["segment_id"]=="HALO-20240921a_e08b"][0]
+plt.scatter(ds_drops.sel(time=slice(seg["start"], seg["end"])).lon,
+         ds_drops.sel(time=slice(seg["start"], seg["end"])).lat)
+if "extra_sondes" in seg.keys():
+    plt.scatter(ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lon,
+                ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lat)
+```
+
+```python
+fig, ax = plt.subplots()
+
+for k, c in zip(['straight_leg', 'circle', ], ["C0", "C1"]):
+    for s in flight["segments"]:
+        if k in s["kinds"]:
+            t = slice(s["start"], s["end"])
+            ax.plot(ds.lon.sel(time=t), ds.lat.sel(time=t), c=c, label=s["name"])
+ax.set_xlabel("longitude / °")
+ax.set_ylabel("latitude / °");
+```

--- a/scripts/segmentation_HALO-20240921a.md
+++ b/scripts/segmentation_HALO-20240921a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240923a.md
+++ b/scripts/segmentation_HALO-20240923a.md
@@ -44,7 +44,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240923a.md
+++ b/scripts/segmentation_HALO-20240923a.md
@@ -430,7 +430,7 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
 kinds
 ```
 

--- a/scripts/segmentation_HALO-20240924a.md
+++ b/scripts/segmentation_HALO-20240924a.md
@@ -371,7 +371,8 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240924a.md
+++ b/scripts/segmentation_HALO-20240924a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240926a.md
+++ b/scripts/segmentation_HALO-20240926a.md
@@ -204,7 +204,7 @@ sl4 = (
 )
 
 c4 = (
-    slice("2024-09-26T16:06:15", "2024-09-26T17:12:00"),
+    slice("2024-09-26T16:06:15", "2024-09-26T17:05:10"),
     ["circle", "circle_clockwise"],
     "circle_4",
     ["no permission to drop sondes in northern half of the circle, four sondes dropped inside circle instead"]

--- a/scripts/segmentation_HALO-20240926a.md
+++ b/scripts/segmentation_HALO-20240926a.md
@@ -364,3 +364,47 @@ yaml.dump(to_yaml(platform, flight_id, ds, segments, events),
           open(f"../flight_segment_files/{flight_id}.yaml", "w"),
           sort_keys=False)
 ```
+
+## Import YAML and test it
+
+```python
+flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
+```
+
+```python
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+Print circle segments with extra sondes
+
+```python
+[s for s in flight["segments"] if ("circle" in s["kinds"] and "extra_sondes" in s.keys())]
+```
+
+Plot all sondes related to a circle segment indetified by it's id
+
+```python
+seg = [s for s in flight["segments"] if s["segment_id"]=="HALO-20240926a_f31e"][0]
+plt.scatter(ds_drops.sel(time=slice(seg["start"], seg["end"])).lon,
+         ds_drops.sel(time=slice(seg["start"], seg["end"])).lat)
+if "extra_sondes" in seg.keys():
+    plt.scatter(ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lon,
+                ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lat)
+```
+
+```python
+fig, ax = plt.subplots()
+
+for k, c in zip(['straight_leg', 'circle', ], ["C0", "C1"]):
+    for s in flight["segments"]:
+        if k in s["kinds"]:
+            t = slice(s["start"], s["end"])
+            ax.plot(ds.lon.sel(time=t), ds.lat.sel(time=t), c=c, label=s["name"])
+ax.set_xlabel("longitude / °")
+ax.set_ylabel("latitude / °");
+```
+
+```python
+
+```

--- a/scripts/segmentation_HALO-20240926a.md
+++ b/scripts/segmentation_HALO-20240926a.md
@@ -207,7 +207,11 @@ c4 = (
     slice("2024-09-26T16:06:15", "2024-09-26T17:05:10"),
     ["circle", "circle_clockwise"],
     "circle_4",
-    ["no permission to drop sondes in northern half of the circle, four sondes dropped inside circle instead"]
+    ["no permission to drop sondes in northern half of the circle, four sondes dropped inside circle instead"],
+    [str(ds_drops.sel(time="2024-09-26T17:23:25").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-26T17:28:03").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-26T17:32:37").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-26T17:37:25").sonde_id.values)],
 )
 
 ec1 = (
@@ -223,7 +227,9 @@ c5 = (
     slice("2024-09-26T18:25:26", "2024-09-26T19:17:46"),
     ["circle", "circle_clockwise"],
     "circle_5",
-    ["irregularity: roll angle deviation of +0.8 between 18:30:42 and 18:37:22"]
+    ["irregularity: roll angle deviation of +0.8 between 18:30:42 and 18:37:22"],
+    [str(ds_drops.sel(time="2024-09-26T19:23:39").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-26T19:28:17").sonde_id.values)],
 )
 
 sl5 = (

--- a/scripts/segmentation_HALO-20240926a.md
+++ b/scripts/segmentation_HALO-20240926a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240928a.md
+++ b/scripts/segmentation_HALO-20240928a.md
@@ -46,7 +46,9 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest") \
+             .swap_dims({"sonde_id": "time"}) \
+             .sortby("time")
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_HALO-20240928a.md
+++ b/scripts/segmentation_HALO-20240928a.md
@@ -414,7 +414,25 @@ yaml.dump(to_yaml(platform, flight_id, ds, segments, events),
 
 ```python
 flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
+```
+
+Print circle segments with extra sondes
+
+```python
+[s for s in flight["segments"] if ("circle" in s["kinds"] and "extra_sondes" in s.keys())]
+```
+
+Plot all sondes related to a circle segment indetified by it's id
+
+```python
+seg = [s for s in flight["segments"] if s["segment_id"]=="HALO-20240928a_8cd2"][0]
+plt.scatter(ds_drops.sel(time=slice(seg["start"], seg["end"])).lon,
+         ds_drops.sel(time=slice(seg["start"], seg["end"])).lat)
+if "extra_sondes" in seg.keys():
+    plt.scatter(ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lon,
+                ds_drops.swap_dims({"time": "sonde_id"}).sel(sonde_id=seg["extra_sondes"]).lat)
 ```
 
 ```python

--- a/scripts/segmentation_HALO-20240928a.md
+++ b/scripts/segmentation_HALO-20240928a.md
@@ -188,6 +188,8 @@ c2 = (
     ["irregularity: early start due to first sonde. Roll angle stable after 13:42:38.",
      "irregularity: few height level jumps by up to 30m and concurrent roll angle change by about 1deg",
     ],
+    [str(ds_drops.sel(time="2024-09-28T14:48:34").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-28T14:55:26").sonde_id.values)],
 )
 
 sl3a = (
@@ -215,6 +217,9 @@ c3 = (
     slice("2024-09-28T15:27:44", "2024-09-28T16:23:17"),
     ["circle", "circle_clockwise"],
     "cirlce_3",
+    [],
+    [str(ds_drops.sel(time="2024-09-28T15:09:12").sonde_id.values),
+     str(ds_drops.sel(time="2024-09-28T15:16:22").sonde_id.values)],
 )
 
 sl4 = (
@@ -260,7 +265,8 @@ c5 = (
     slice("2024-09-28T18:15:44", "2024-09-28T19:10:07"),
     ["circle", "circle_clockwise"],
     "circle_5",
-    ["circle path crosses PACE track"]
+    ["circle path crosses PACE track"],
+    [str(ds_drops.sel(time="2024-09-28T19:14:52").sonde_id.values)],
 )
 
 sl6 = (

--- a/scripts/segmentation_HALO-20240929a.md
+++ b/scripts/segmentation_HALO-20240929a.md
@@ -407,7 +407,8 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
 ```
 
 ```python
@@ -420,20 +421,4 @@ for k, c in zip(['straight_leg', 'circle', ], ["C0", "C1"]):
             ax.plot(ds.lon.sel(time=t), ds.lat.sel(time=t), c=c, label=s["name"])
 ax.set_xlabel("longitude / °")
 ax.set_ylabel("latitude / °");
-```
-
-### Check circle radius
-
-```python
-from orcestra.flightplan import LatLon, FlightPlan, IntoCircle
-
-for s in flight["segments"]:
-    if "circle" not in s["kinds"]: continue
-    d = ds.sel(time=slice(s["start"], s["end"]))
-    start = LatLon(float(d.lat[0]), float(d.lon[0]), label="start")
-    center = LatLon(s["clat"], s["clon"], label="center")
-    FlightPlan([start, IntoCircle(center, s["radius"], 360)]).preview()
-    print(f"Radius: {round(s["radius"])} m")
-    plt.plot(d.lon, d.lat, label="HALO track")
-    plt.legend()
 ```

--- a/scripts/segmentation_HALO-20240929a.md
+++ b/scripts/segmentation_HALO-20240929a.md
@@ -56,7 +56,7 @@ No sondes dropped during this flight.
 
 ```python
 #drops = get_sondes_l1(flight_id)
-#ds_drops = ds.sel(time=drops, method="nearest")
+#ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/segmentation_template.md
+++ b/scripts/segmentation_template.md
@@ -304,7 +304,8 @@ flight = yaml.safe_load(open(f"../flight_segment_files/{flight_id}.yaml", "r"))
 ```
 
 ```python
-kinds = set(k for s in segments for k in s["kinds"])
+kinds = set(k for s in flight["segments"] for k in s["kinds"])
+kinds
 ```
 
 ```python

--- a/scripts/segmentation_template.md
+++ b/scripts/segmentation_template.md
@@ -53,7 +53,7 @@ ds = get_navdata_HALO(flight_id)
 
 ```python
 drops = get_sondes_l1(flight_id)
-ds_drops = ds.sel(time=drops, method="nearest")
+ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 
 ### Defining takeoff and landing

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -344,6 +344,8 @@ def parse_segment(segment):
             seg["name"] = segment[2]
         if len(segment) >= 4:
             seg["remarks"] = segment[3]
+        if len(segment) >= 5:
+            seg["extra_sondes"] = segment[4]
     elif isinstance(segment, dict):
         return segment
     else:

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -25,13 +25,21 @@ def get_sondes_l1(flight_id):
     import xarray as xr
     import numpy as np
     import pandas as pd
-    root = "ipns://latest.orcestra-campaign.org/products/HALO/dropsondes/Level_1"
+    #root = "ipns://latest.orcestra-campaign.org/products/HALO/dropsondes/Level_1"
+    root = "ipfs://QmVMtDX1fZfL3SgNaXXt1wtW3htnC2vFbzx2ENN1cxrzSx"
     day_folder = root + "/" + flight_id
-    fs = fsspec.filesystem(day_folder.split(":")[0])
+    protocol = day_folder.split(":")[0]
+    fs = fsspec.filesystem(protocol)
     filenames = fs.glob(day_folder + "/*.nc")
-    datasets = [xr.open_dataset(fsspec.open_local("simplecache::ipns://" + filename), engine="netcdf4")
-                for filename in filenames if fs.size("ipns://" + filename)]
-    return pd.to_datetime(np.array([d["launch_time"].values for d in datasets])).sort_values().values
+    datasets = []
+    for filename in filenames:
+        try:
+            datasets.append(xr.open_dataset(fsspec.open_local(f"simplecache::{protocol}://{filename}"), engine="netcdf4"))
+        except IOError:
+            print(f"cannot read {filename}.")
+    lt, sonde_id = zip(*[(d["launch_time"].values, d.attrs["SondeId"]) for d in datasets])
+    return xr.Dataset({"launch_time": (["sonde_id"], list(lt)),
+                       "sonde_id": (["sonde_id"], list(sonde_id))})
 
 def get_overpass_point(ds, target_lat, target_lon):
     import numpy as np


### PR DESCRIPTION
This PR updates the circle segments including a few necessary changes:
* it implements our current circle definition that limits circles to 360deg with an exception made only for early/late dropsondes. Circles with continued flight track on a circular path before or after a circle with 360deg were shortened respectively. The main reason for this decision is a better comparability between measurements from dropsondes and other instruments for certain circle segments
* the [get_sondes_l1](https://github.com/orcestra-campaign/flight_segmentation/blob/main/scripts/utils.py#L23-L34) function was based on IPNS making the info unstable. As it actually happened that the dropsonde files at "latest.orcestra..." had changed, I changed this function to (1) refer to a fix hash on IPFS (2) handle broken files (3) return not only the launch time, but also the sonde_id. All notebooks had to be changed accordingly where dropsonde data is loaded.
* using the now available sonde_id information, I added `extra_sondes` to circle segments in form of a list of strings. All sondes added lie within the respective circles and within 20 min pre/post to the circle.
* finally, I added tests to the end of all notebooks if they weren't already there. Some notebooks were only changed marginally, others didn't have any tests so far. It should be slightly more consistent among the notebooks with this last commit.