### PR TITLE
Update drop l2

### DIFF
--- a/scripts/segmentation_HALO-20240811a.md
+++ b/scripts/segmentation_HALO-20240811a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240813a.md
+++ b/scripts/segmentation_HALO-20240813a.md
@@ -62,7 +62,7 @@ ds = xr.concat([ds0, dslow.sel(time=slice(ds0.time[-1]+np.timedelta64(1, "s"), N
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240816a.md
+++ b/scripts/segmentation_HALO-20240816a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240818a.md
+++ b/scripts/segmentation_HALO-20240818a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240821a.md
+++ b/scripts/segmentation_HALO-20240821a.md
@@ -52,7 +52,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240822a.md
+++ b/scripts/segmentation_HALO-20240822a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240825a.md
+++ b/scripts/segmentation_HALO-20240825a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240827a.md
+++ b/scripts/segmentation_HALO-20240827a.md
@@ -46,7 +46,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest") \
              .swap_dims({"sonde_id": "time"}) \
              .sortby("time")

--- a/scripts/segmentation_HALO-20240829a.md
+++ b/scripts/segmentation_HALO-20240829a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240831a.md
+++ b/scripts/segmentation_HALO-20240831a.md
@@ -49,7 +49,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240903a.md
+++ b/scripts/segmentation_HALO-20240903a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240906a.md
+++ b/scripts/segmentation_HALO-20240906a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240907a.md
+++ b/scripts/segmentation_HALO-20240907a.md
@@ -45,7 +45,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240909a.md
+++ b/scripts/segmentation_HALO-20240909a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240912a.md
+++ b/scripts/segmentation_HALO-20240912a.md
@@ -53,7 +53,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240914a.md
+++ b/scripts/segmentation_HALO-20240914a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240916a.md
+++ b/scripts/segmentation_HALO-20240916a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240919a.md
+++ b/scripts/segmentation_HALO-20240919a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240921a.md
+++ b/scripts/segmentation_HALO-20240921a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240923a.md
+++ b/scripts/segmentation_HALO-20240923a.md
@@ -43,7 +43,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240924a.md
+++ b/scripts/segmentation_HALO-20240924a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240926a.md
+++ b/scripts/segmentation_HALO-20240926a.md
@@ -48,7 +48,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 

--- a/scripts/segmentation_HALO-20240928a.md
+++ b/scripts/segmentation_HALO-20240928a.md
@@ -45,7 +45,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest") \
              .swap_dims({"sonde_id": "time"}) \
              .sortby("time")

--- a/scripts/segmentation_template.md
+++ b/scripts/segmentation_template.md
@@ -52,7 +52,7 @@ ds = get_navdata_HALO(flight_id)
 ### Get dropsonde launch times
 
 ```python
-drops = get_sondes_l1(flight_id)
+drops = get_sondes_l2(flight_id)
 ds_drops = ds.sel(time=drops.launch_time, method="nearest").swap_dims({"sonde_id": "time"})
 ```
 


### PR DESCRIPTION
The flight segmentation is partly based on dropsonde data. The dropsonde datasets have been updated such that we decided to use the Level 2 dropsonde data with unique sonde identifiers for the flight segmentation. This PR updates the function for getting dropsonde data to read Level 2 data from IPFS. The flight notebooks are adapted to reflect the new function name `get_sondes_l2` and the reports are adjusted as well to the new dropsonde info.