### PR TITLE
add missing meteor_coordination tag on 0831

### DIFF
--- a/scripts/segmentation_HALO-20240831a.md
+++ b/scripts/segmentation_HALO-20240831a.md
@@ -225,7 +225,7 @@ seg12 = (
 
 seg13 = (
     slice("2024-08-31T12:52:25", "2024-08-31T13:48:01"),
-    ["circle", "circle_counterclockwise"],
+    ["circle", "circle_counterclockwise", "meteor_coordination"],
     "circle_mid",
     ["irregularity: turbulence with up to plus/minus 4.5 degree roll angle deviation"],
     [str(ds_drops.sel(time="2024-08-31T14:05:21").sonde_id.values)],


### PR DESCRIPTION
@allison-wing pointed out that the circle segment `HALO-20240831a_33ff` was missing the tag for `meteor_coordination`. This PR adds the respective tag. METEOR was situated in the northern part of the circle and SEA-POL nicely covered the circle area with its scans :) Thanks Allison for the correction!!