### PR TITLE
Convert `kinds` entry to list during ATR normalisation

### DIFF
--- a/scripts/merge_segments.py
+++ b/scripts/merge_segments.py
@@ -10,7 +10,7 @@ def normalize_atr_segment(segment, flight_id):
         "name": segment["name"],
         "start": segment["start"],
         "end": segment["end"],
-        "kinds": segment["kind"],
+        "kinds": list([segment["kind"]]) if isinstance(segment["kind"], str) else segment["kind"],
         "remarks": segment.get("note") or [],
     }
 


### PR DESCRIPTION
This PR fixes the normalisation of ATR flight segmentations.

During the creation of the `all_flights.yaml` both the HALO and ATR flight segmentations are normalised for consistency. However, currently the `kinds` entry in segments is of type `list` for HALO and `str` for ATR, which is annoying for users. This PR converts the `kinds` entries to type `list` for the ATR.